### PR TITLE
webtv: fix early exception issue

### DIFF
--- a/src/devices/cpu/mips/mips3drc.cpp
+++ b/src/devices/cpu/mips/mips3drc.cpp
@@ -740,6 +740,10 @@ void mips3_device::static_generate_exception(uint8_t exception, int recover, con
 		offset = 0x000;
 		exception = (exception - EXCEPTION_TLBLOAD_FILL) + EXCEPTION_TLBLOAD;
 	}
+	else if (exception == EXCEPTION_INTERRUPT && m_flavor == MIPS3_TYPE_R4640)
+	{
+		offset = 0x200;
+	}
 
 	/* begin generating */
 	drcuml_block &block(m_drcuml->begin_block(1024));


### PR DESCRIPTION
This should fix the interrupt issue that happens right after the bootrom cache init.