### PR TITLE
Audio, watchdog  counter and other fixes

### DIFF
--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -209,9 +209,9 @@ mips3_device::mips3_device(const machine_config &mconfig, device_type type, cons
 
 	// configure the virtual TLB
 	if (m_flavor == MIPS3_TYPE_TX4925)
-		set_vtlb_fixed_entries(2 * m_tlbentries + 3);
+		set_vtlb_fixed_entries(2 * m_tlbentries + 4);
 	else
-		set_vtlb_fixed_entries(2 * m_tlbentries + 2);
+		set_vtlb_fixed_entries(2 * m_tlbentries + 3);
 }
 
 device_memory_interface::space_config_vector mips3_device::memory_space_config() const
@@ -1125,16 +1125,18 @@ void mips3_device::device_reset()
 		entry->entry_lo[1] = 0xfffffff8;
 		vtlb_load(2 * tlbindex + 0, 0, 0, 0);
 		vtlb_load(2 * tlbindex + 1, 0, 0, 0);
+		vtlb_load(2 * tlbindex + 2, 0, 0, 0);
 		if (m_flavor == MIPS3_TYPE_TX4925)
-			vtlb_load(2 * tlbindex + 2, 0, 0, 0);
+			vtlb_load(2 * tlbindex + 3, 0, 0, 0);
 	}
 
 	/* load the fixed TLB range */
 	vtlb_load(2 * m_tlbentries + 0, (0xa0000000 - 0x80000000) >> MIPS3_MIN_PAGE_SHIFT, 0x80000000, 0x00000000 | READ_ALLOWED | WRITE_ALLOWED | FETCH_ALLOWED | FLAG_VALID);
 	vtlb_load(2 * m_tlbentries + 1, (0xc0000000 - 0xa0000000) >> MIPS3_MIN_PAGE_SHIFT, 0xa0000000, 0x00000000 | READ_ALLOWED | WRITE_ALLOWED | FETCH_ALLOWED | FLAG_VALID);
+	vtlb_load(2 * m_tlbentries + 2, (0xe0000000 - 0xc0000000) >> MIPS3_MIN_PAGE_SHIFT, 0xc0000000, 0x00000000 | READ_ALLOWED | WRITE_ALLOWED | FETCH_ALLOWED | FLAG_VALID);
 	// TX4925 on-board peripherals pass-through
 	if (m_flavor == MIPS3_TYPE_TX4925)
-		vtlb_load(2 * m_tlbentries + 2, (0xff200000 - 0xff1f0000) >> MIPS3_MIN_PAGE_SHIFT, 0xff1f0000, 0xff1f0000 | READ_ALLOWED | WRITE_ALLOWED | FETCH_ALLOWED | FLAG_VALID);
+		vtlb_load(2 * m_tlbentries + 3, (0xff200000 - 0xff1f0000) >> MIPS3_MIN_PAGE_SHIFT, 0xff1f0000, 0xff1f0000 | READ_ALLOWED | WRITE_ALLOWED | FETCH_ALLOWED | FLAG_VALID);
 	m_tlb_seed = 0;
 
 	m_core->mode = (MODE_KERNEL << 1) | 0;

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -420,10 +420,7 @@ void spot_asic_device::reg_0108_w(uint32_t data)
 {
 	logerror("%s: reg_0108_w %08x (BUS_INTSTAT clear)\n", machine().describe_context(), data);
 
-	if (data & BUS_INT_VIDINT)
-		spot_asic_device::set_vid_irq(0xf, 0);
-
-	m_intstat &= (~data) & 0xFF;
+	spot_asic_device::set_bus_irq(data, 0);
 }
 
 uint32_t spot_asic_device::reg_000c_r()
@@ -1375,7 +1372,6 @@ void spot_asic_device::irq_smartcard_w(int state)
 
 void spot_asic_device::irq_audio_w(int state)
 {
-	m_intenable |= BUS_INT_AUDDMA;
 	spot_asic_device::set_bus_irq(BUS_INT_AUDDMA, state);
 }
 
@@ -1406,8 +1402,6 @@ void spot_asic_device::set_vid_irq(uint8_t mask, int state)
 			m_vid_intstat |= mask;
 		else
 			m_vid_intstat &= ~(mask);
-
-		m_intenable |= BUS_INT_VIDINT;
 
 		spot_asic_device::set_bus_irq(BUS_INT_VIDINT, state);
 	}

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -1170,7 +1170,7 @@ void spot_asic_device::reg_4040_w(uint32_t data)
 	{
 		modem_txbuff[modem_txbuff_size++ & (MBUFF_MAX_SIZE - 1)] = data & 0xFF;
 
-		modem_buffer_timer->adjust(attotime::from_usec(1000));
+		modem_buffer_timer->adjust(attotime::from_usec(MBUFF_FLUSH_TIME));
 	}
 }
 
@@ -1384,7 +1384,7 @@ TIMER_CALLBACK_MEMBER(spot_asic_device::flush_modem_buffer)
 
 	if(modem_txbuff_size > 0)
 	{
-		modem_buffer_timer->adjust(attotime::from_usec(1000));
+		modem_buffer_timer->adjust(attotime::from_usec(MBUFF_FLUSH_TIME));
 	}
 }
 

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -1071,13 +1071,13 @@ void spot_asic_device::reg_4020_w(uint32_t data)
 uint32_t spot_asic_device::reg_4024_r()
 {
 	logerror("%s: reg_4024_r (DEV_KBD1)\n", machine().describe_context());
-	return m_kbdc->data_r(0x1);
+	return m_kbdc->data_r(0x4);
 }
 
 void spot_asic_device::reg_4024_w(uint32_t data)
 {
 	logerror("%s: reg_4024_w %08x (DEV_KBD1)\n", machine().describe_context(), data);
-	m_kbdc->data_w(0x1, data & 0xFF);
+	m_kbdc->data_w(0x4, data & 0xFF);
 }
 
 uint32_t spot_asic_device::reg_4028_r()
@@ -1107,13 +1107,13 @@ void spot_asic_device::reg_402c_w(uint32_t data)
 uint32_t spot_asic_device::reg_4030_r()
 {
 	logerror("%s: reg_4030_r (DEV_KBD4)\n", machine().describe_context());
-	return m_kbdc->data_r(0x4);
+	return m_kbdc->data_r(0x1);
 }
 
 void spot_asic_device::reg_4030_w(uint32_t data)
 {
 	logerror("%s: reg_4030_w %08x (DEV_KBD4)\n", machine().describe_context(), data);
-	m_kbdc->data_w(0x4, data & 0xFF);
+	m_kbdc->data_w(0x1, data & 0xFF);
 }
 
 uint32_t spot_asic_device::reg_4034_r()

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -124,7 +124,8 @@
 
 #define INS8250_LSR_TSRE 0x40
 #define INS8250_LSR_THRE 0x20
-#define MBUFF_MAX_SIZE   0x1000
+#define MBUFF_MAX_SIZE   0x800
+#define MBUFF_FLUSH_TIME 100
 
 class spot_asic_device : public device_t, public device_serial_interface, public device_video_interface
 {

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -257,9 +257,6 @@ private:
 	void validate_active_area();
 	void spot_update_cycle_counting();
 	
-	TIMER_CALLBACK_MEMBER(vid_dma_complete);
-	//TIMER_CALLBACK_MEMBER(aud_dma_complete);
-
 	/* busUnit registers */
 
     uint32_t reg_0000_r();          // BUS_CHIPID (read-only)

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -30,6 +30,7 @@
 #include "machine/ins8250.h"
 #include "sound/dac.h"
 #include "speaker.h"
+#include "machine/watchdog.h"
 
 #define SYSCONFIG_ROMTYP0    1 << 31 // ROM bank 0 is present
 #define SYSCONFIG_ROMMODE0   1 << 30 // ROM bank 0 supports page mode
@@ -53,6 +54,8 @@
 #define ERR_F2WRITE 1 << 3 // BUS_FENADDR2 write fence check error
 #define ERR_TIMEOUT 1 << 2 // io timeout error
 #define ERR_OW      1 << 0 // double-fault
+
+#define WATCHDOG_TIMER_USEC 1000000
 
 #define BUS_INT_VIDINT 1 << 7 // vidUnit interrupt (program should read VID_INTSTAT)
 #define BUS_INT_DEVKBD 1 << 6 // keyboard IRQ
@@ -153,6 +156,9 @@ protected:
 	void activate_ntsc_screen();
 	void activate_pal_screen();
 
+	uint32_t m_chpcntl;
+	uint8_t m_wdenable;
+
 	uint32_t m_fence1_addr;
 	uint32_t m_fence1_mask;
 	uint32_t m_fence2_addr;
@@ -227,6 +233,8 @@ private:
 	required_device<speaker_device> m_rspeaker;
 
 	required_device<ins8250_device> m_modem_uart;
+	
+	required_device<watchdog_timer_device> m_watchdog;
 
 	required_ioport m_sys_config;
 	required_ioport m_emu_config;
@@ -256,7 +264,8 @@ private:
 
 	void validate_active_area();
 	void spot_update_cycle_counting();
-	
+	void watchdog_enable(int state);
+
 	/* busUnit registers */
 
     uint32_t reg_0000_r();          // BUS_CHIPID (read-only)


### PR DESCRIPTION
This should contain:

- Code to implement  audio.
- Fix for the CACHE ERROR when you power on and off an approm.
- Watchdog counter so it'll reset after power off.
- "keyboard error" fix on boot that also fixes powering up an approm after reset.
- Fixes some interrupt issues that broke some approms.
- Modem buffer adjustments discussed in the #wtv-dev discord channel.