### PR TITLE
SSID and modem fixes

### DIFF
--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -189,7 +189,7 @@ void spot_asic_device::device_add_mconfig(machine_config &config)
 	DAC_16BIT_R2R_TWOS_COMPLEMENT(config, m_dac[0], 0).add_route(0, m_lspeaker, 0.0);
 	DAC_16BIT_R2R_TWOS_COMPLEMENT(config, m_dac[1], 0).add_route(0, m_rspeaker, 0.0);
 
-	INS8250(config, m_modem_uart, 1.8432_MHz_XTAL);
+	NS16550(config, m_modem_uart, 1.8432_MHz_XTAL);
 	m_modem_uart->out_tx_callback().set("modem", FUNC(rs232_port_device::write_txd));
 	m_modem_uart->out_dtr_callback().set("modem", FUNC(rs232_port_device::write_dtr));
 	m_modem_uart->out_rts_callback().set("modem", FUNC(rs232_port_device::write_rts));
@@ -197,11 +197,11 @@ void spot_asic_device::device_add_mconfig(machine_config &config)
     
 	rs232_port_device &rs232(RS232_PORT(config, "modem", default_rs232_devices, "null_modem"));
     rs232.set_option_device_input_defaults("null_modem", DEVICE_INPUT_DEFAULTS_NAME(wtv_modem));
-	rs232.rxd_handler().set(m_modem_uart, FUNC(ins8250_uart_device::rx_w));
-	rs232.dcd_handler().set(m_modem_uart, FUNC(ins8250_uart_device::dcd_w));
-	rs232.dsr_handler().set(m_modem_uart, FUNC(ins8250_uart_device::dsr_w));
-	rs232.ri_handler().set(m_modem_uart, FUNC(ins8250_uart_device::ri_w));
-	rs232.cts_handler().set(m_modem_uart, FUNC(ins8250_uart_device::cts_w));
+	rs232.rxd_handler().set(m_modem_uart, FUNC(ns16450_device::rx_w));
+	rs232.dcd_handler().set(m_modem_uart, FUNC(ns16450_device::dcd_w));
+	rs232.dsr_handler().set(m_modem_uart, FUNC(ns16450_device::dsr_w));
+	rs232.ri_handler().set(m_modem_uart, FUNC(ns16450_device::ri_w));
+	rs232.cts_handler().set(m_modem_uart, FUNC(ns16450_device::cts_w));
 
 	KBDC8042(config, m_kbdc);
 	m_kbdc->set_keyboard_type(kbdc8042_device::KBDC8042_PS2);

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -127,6 +127,15 @@
 #define MBUFF_MAX_SIZE   0x800
 #define MBUFF_FLUSH_TIME 100
 
+#define SSID_STATE_IDLE               0x0
+#define SSID_STATE_RESET              0x1
+#define SSID_STATE_PRESENCE           0x2
+#define SSID_STATE_COMMAND            0x3
+#define SSID_STATE_READROM            0x4
+#define SSID_STATE_READROM_PULSESTART 0x5
+#define SSID_STATE_READROM_PULSEEND   0x6
+#define SSID_STATE_READROM_BIT        0x7
+
 class spot_asic_device : public device_t, public device_serial_interface, public device_video_interface
 {
 public:
@@ -215,6 +224,11 @@ protected:
 	uint32_t m_aud_nsize;
 	uint32_t m_aud_nconfig;
 	uint32_t m_aud_dmacntl;
+
+	uint32_t dev_idcntl;
+	uint8_t dev_id_state;
+	uint8_t dev_id_bit;
+	uint8_t dev_id_bitidx;
 
 	uint16_t m_smrtcrd_serial_bitmask = 0x0;
 	uint16_t m_smrtcrd_serial_rxdata = 0x0;

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -247,7 +247,7 @@ private:
 	required_device<speaker_device> m_lspeaker;
 	required_device<speaker_device> m_rspeaker;
 
-	required_device<ins8250_device> m_modem_uart;
+	required_device<ns16550_device> m_modem_uart;
 	
 	required_device<watchdog_timer_device> m_watchdog;
 


### PR DESCRIPTION
This should contain:

- SSID implementation
- Change the UART chip so there's less modem errors
~~- Remove the flash byte swapping to prepare for flash programming. The flash chip commands aren't received correctly with byte swapping.~~