### PR TITLE
Multiple fixes and improvements

### DIFF
--- a/src/devices/cpu/mips/mips3.cpp
+++ b/src/devices/cpu/mips/mips3.cpp
@@ -4101,6 +4101,16 @@ void mips3_device::handle_idt(uint32_t op)
 {
 	switch (op & 0x1f)
 	{
+		case 0: /* MADD */
+		{
+			uint64_t temp64 = (int64_t)((int32_t)RSVAL32 * (int32_t)RTVAL32);
+			LOVAL64 += (int32_t)temp64;
+			HIVAL64 += (int32_t)(temp64 >> 32);
+			if (RDREG)
+				RDVAL64 = LOVAL;
+			m_core->icount -= 3;
+			break;
+		}
 		case 2: /* MUL */
 			RDVAL64 = (int32_t)((int32_t)RSVAL32 * (int32_t)RTVAL32);
 			m_core->icount -= 3;

--- a/src/devices/cpu/mips/mips3.h
+++ b/src/devices/cpu/mips/mips3.h
@@ -542,6 +542,7 @@ public:
 	void mips3com_tlbwi();
 	void mips3com_tlbwr();
 	void mips3com_tlbp();
+	void code_flush_cache();
 private:
 	uint32_t compute_config_register();
 	uint32_t compute_prid_register();
@@ -606,7 +607,6 @@ private:
 	void sdr_le(uint32_t op);
 	void load_fast_iregs(drcuml_block &block);
 	void save_fast_iregs(drcuml_block &block);
-	void code_flush_cache();
 	void code_compile_block(uint8_t mode, offs_t pc);
 public:
 	void func_get_cycles();

--- a/src/devices/machine/intelfsh.cpp
+++ b/src/devices/machine/intelfsh.cpp
@@ -92,15 +92,18 @@ DEFINE_DEVICE_TYPE(AMD_29F400T,           amd_29f400t_device,           "amd_29f
 DEFINE_DEVICE_TYPE(AMD_29F800T,           amd_29f800t_device,           "amd_29f800t",           "AMD 29F800T Flash")
 DEFINE_DEVICE_TYPE(AMD_29F800B_16BIT,     amd_29f800b_16bit_device,     "amd_29f800b_16bit",     "AMD 29F800B Flash (16-bit)")
 DEFINE_DEVICE_TYPE(AMD_29LV200T,          amd_29lv200t_device,          "amd_29lv200t",          "AMD 29LV200T Flash")
+DEFINE_DEVICE_TYPE(AMD_29LV800B_16BIT,    amd_29lv800b_16bit_device,    "amd_29lv800b_16bit",    "AMD 29LV800B Flash")
 DEFINE_DEVICE_TYPE(FUJITSU_29F160TE,      fujitsu_29f160te_device,      "mbm29f160te",           "Fujitsu MBM29F160TE Flash")
 DEFINE_DEVICE_TYPE(FUJITSU_29F016A,       fujitsu_29f016a_device,       "mbm29f016a",            "Fujitsu MBM29F016A Flash")
 DEFINE_DEVICE_TYPE(FUJITSU_29DL164BD,     fujitsu_29dl164bd_device,     "mbm29dl164bd",          "Fujitsu MBM29DL164BD Flash")
 DEFINE_DEVICE_TYPE(FUJITSU_29LV002TC,     fujitsu_29lv002tc_device,     "mbm29lv002tc",          "Fujitsu MBM29LV002TC Flash")
 DEFINE_DEVICE_TYPE(FUJITSU_29LV800B,      fujitsu_29lv800b_device,      "mbm29lv800b",           "Fujitsu MBM29LV800B Flash")
+DEFINE_DEVICE_TYPE(FUJITSU_29F400T_16BIT, fujitsu_29f400t_16bit_device, "mbm29f400t_16bit",      "Fujitsu MBM29F400T Flash (16-bit)")
 DEFINE_DEVICE_TYPE(INTEL_E28F400B,        intel_e28f400b_device,        "intel_e28f400b",        "Intel E28F400B Flash")
 DEFINE_DEVICE_TYPE(MACRONIX_29F008TC,     macronix_29f008tc_device,     "macronix_29f008tc",     "Macronix 29F008TC Flash")
 DEFINE_DEVICE_TYPE(MACRONIX_29L001MC,     macronix_29l001mc_device,     "macronix_29l001mc",     "Macronix 29L001MC Flash")
 DEFINE_DEVICE_TYPE(MACRONIX_29LV160TMC,   macronix_29lv160tmc_device,   "macronix_29lv160tmc",   "Macronix 29LV160TMC Flash")
+DEFINE_DEVICE_TYPE(MACRONIX_29F1610,      macronix_29f1610_device,      "macronix_29f1610",      "Macronix MX29F1610 Flash")
 DEFINE_DEVICE_TYPE(TMS_29F040,            tms_29f040_device,            "tms_29f040",            "Texas Instruments 29F040 Flash")
 
 DEFINE_DEVICE_TYPE(PANASONIC_MN63F805MNP, panasonic_mn63f805mnp_device, "panasonic_mn63f805mnp", "Panasonic MN63F805MNP Flash")
@@ -187,6 +190,9 @@ fujitsu_29lv002tc_device::fujitsu_29lv002tc_device(const machine_config &mconfig
 
 fujitsu_29lv800b_device::fujitsu_29lv800b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh16_device(mconfig, FUJITSU_29LV800B, tag, owner, clock, 0x100000, MFG_FUJITSU, 0x225b) { m_bot_boot_sector = true; }
+	
+fujitsu_29f400t_16bit_device::fujitsu_29f400t_16bit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: intelfsh16_device(mconfig, FUJITSU_29F400T_16BIT, tag, owner, clock, 0x100000, MFG_FUJITSU, 0x2223) { m_top_boot_sector = true; }
 
 sharp_lh28f016s_device::sharp_lh28f016s_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, SHARP_LH28F016S, tag, owner, clock, 0x200000, MFG_INTEL, 0xaa) { }
@@ -221,6 +227,9 @@ amd_29f800b_16bit_device::amd_29f800b_16bit_device(const machine_config &mconfig
 amd_29lv200t_device::amd_29lv200t_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, AMD_29LV200T, tag, owner, clock, 0x40000, MFG_AMD, 0x3b) { }
 
+amd_29lv800b_16bit_device::amd_29lv800b_16bit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: intelfsh16_device(mconfig, AMD_29LV800B_16BIT, tag, owner, clock, 0x100000, MFG_AMD, 0x22da) { m_top_boot_sector = true; }
+
 cat28f020_device::cat28f020_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, CAT28F020, tag, owner, clock, 0x40000, MFG_CATALYST, 0xbd) { }
 
@@ -235,6 +244,9 @@ macronix_29l001mc_device::macronix_29l001mc_device(const machine_config &mconfig
 
 macronix_29lv160tmc_device::macronix_29lv160tmc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, MACRONIX_29LV160TMC, tag, owner, clock, 0x20000, MFG_MACRONIX, 0x49) { m_sector_is_16k = true; }
+
+macronix_29f1610_device::macronix_29f1610_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
+	: intelfsh16_device(mconfig, MACRONIX_29F1610, tag, owner, clock, 0x200000, MFG_MACRONIX, 0x00f1) { m_page_size = 0x40; }
 
 panasonic_mn63f805mnp_device::panasonic_mn63f805mnp_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock)
 	: intelfsh8_device(mconfig, PANASONIC_MN63F805MNP, tag, owner, clock, 0x10000, MFG_PANASONIC, 0x1b) { m_sector_is_4k = true; }
@@ -336,7 +348,10 @@ TIMER_CALLBACK_MEMBER(intelfsh_device::delay_tick)
 	switch( m_flash_mode )
 	{
 	case FM_READSTATUS:
-		m_status = 0x80;
+		if ( (m_maker_id == MFG_MACRONIX && m_device_id == 0xf1) )
+			m_status = 0x20;
+		else
+			m_status = 0x80;
 		break;
 
 	case FM_ERASEAMD4:
@@ -546,10 +561,23 @@ void intelfsh_device::write_full(uint32_t address, uint32_t data)
 		{
 		case 0xf0:
 		case 0xff:  // reset chip mode
-			m_flash_mode = FM_NORMAL;
+			// MX29F1610 needs to be reset with another command
+			if ( !(m_maker_id == MFG_MACRONIX && m_device_id == 0xf1) )
+			{
+				m_flash_mode = FM_NORMAL;
+			}
 			break;
 		case 0x90:  // read ID
-			m_flash_mode = FM_READID;
+			// AM29F800B, AM29LV800B, MBM29F400T and MX29F1610 don't support the 0x90 ID command.
+			if (
+				!(m_maker_id == MFG_FUJITSU && m_device_id == 0x22d6)
+				&& !(m_maker_id == MFG_AMD && m_device_id == 0x2258)
+				&& !(m_maker_id == MFG_AMD && m_device_id == 0x22da)
+				&& !(m_maker_id == MFG_MACRONIX && m_device_id == 0x00f1)
+			)
+			{
+				m_flash_mode = FM_READID;
+			}
 			break;
 		case 0x40:
 		case 0x10:  // program
@@ -653,11 +681,11 @@ void intelfsh_device::write_full(uint32_t address, uint32_t data)
 		}
 		else if( ( address & 0xffff ) == 0x5555 && ( data & 0xff ) == 0xa0 )
 		{
-			if (m_maker_id == MFG_ATMEL && m_device_id == 0xd5)
+			if ( (m_maker_id == MFG_ATMEL && m_device_id == 0xd5) || (m_maker_id == MFG_MACRONIX && m_device_id == 0x00f1) )
 			{
 				m_flash_mode = FM_WRITEPAGEATMEL;
 				m_byte_count = 0;
-			}
+			} 
 			else
 			{
 				m_flash_mode = FM_BYTEPROGRAM;
@@ -849,7 +877,19 @@ void intelfsh_device::write_full(uint32_t address, uint32_t data)
 			{
 				memset(&m_data[base & ~0xffff], 0xff, 64 * 1024);
 				m_erase_sector = address & ((m_bits == 16) ? ~0x7fff : ~0xffff);
-				m_timer->adjust( attotime::from_seconds( 1 ) );
+				if (
+					(m_maker_id == MFG_FUJITSU && m_device_id == 0x22d6)
+					|| (m_maker_id == MFG_AMD && m_device_id == 0x2258)
+					|| (m_maker_id == MFG_AMD && m_device_id == 0x22da)
+					|| (m_maker_id == MFG_MACRONIX && m_device_id == 0x00f1)
+				)
+				{
+					m_timer->adjust( attotime::from_msec( 125 ) );
+				}
+				else
+				{
+					m_timer->adjust( attotime::from_seconds( 1 ) );
+				}
 			}
 
 			m_status = 1 << 3;
@@ -921,7 +961,14 @@ void intelfsh_device::write_full(uint32_t address, uint32_t data)
 
 		if (m_byte_count == m_page_size)
 		{
-			m_flash_mode = FM_NORMAL;
+			if (m_maker_id == MFG_MACRONIX && m_device_id == 0x00f1)
+			{
+				m_flash_mode = FM_READSTATUS;
+			}
+			else
+			{
+				m_flash_mode = FM_NORMAL;
+			}
 		}
 		break;
 	case FM_CLEARPART1:

--- a/src/devices/machine/intelfsh.h
+++ b/src/devices/machine/intelfsh.h
@@ -140,6 +140,12 @@ public:
 	fujitsu_29lv800b_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
+class fujitsu_29f400t_16bit_device : public intelfsh16_device
+{
+public:
+	fujitsu_29f400t_16bit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
 class atmel_29c010_device : public intelfsh8_device
 {
 public:
@@ -188,6 +194,12 @@ public:
 	amd_29lv200t_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
+class amd_29lv800b_16bit_device : public intelfsh16_device
+{
+public:
+	amd_29lv800b_16bit_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
 class sharp_lh28f016s_device : public intelfsh8_device
 {
 public:
@@ -222,6 +234,12 @@ class macronix_29lv160tmc_device : public intelfsh8_device
 {
 public:
 	macronix_29lv160tmc_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
+};
+
+class macronix_29f1610_device : public intelfsh16_device
+{
+public:
+	macronix_29f1610_device(const machine_config &mconfig, const char *tag, device_t *owner, uint32_t clock = 0);
 };
 
 class panasonic_mn63f805mnp_device : public intelfsh8_device
@@ -364,15 +382,18 @@ DECLARE_DEVICE_TYPE(AMD_29F400T,           amd_29f400t_device)
 DECLARE_DEVICE_TYPE(AMD_29F800T,           amd_29f800t_device)
 DECLARE_DEVICE_TYPE(AMD_29F800B_16BIT,     amd_29f800b_16bit_device)
 DECLARE_DEVICE_TYPE(AMD_29LV200T,          amd_29lv200t_device)
+DECLARE_DEVICE_TYPE(AMD_29LV800B_16BIT,    amd_29lv800b_16bit_device)
 DECLARE_DEVICE_TYPE(FUJITSU_29F160TE,      fujitsu_29f160te_device)
 DECLARE_DEVICE_TYPE(FUJITSU_29F016A,       fujitsu_29f016a_device)
 DECLARE_DEVICE_TYPE(FUJITSU_29DL164BD,     fujitsu_29dl164bd_device)
 DECLARE_DEVICE_TYPE(FUJITSU_29LV002TC,     fujitsu_29lv002tc_device)
 DECLARE_DEVICE_TYPE(FUJITSU_29LV800B,      fujitsu_29lv800b_device)
+DECLARE_DEVICE_TYPE(FUJITSU_29F400T_16BIT, fujitsu_29f400t_16bit_device)
 DECLARE_DEVICE_TYPE(INTEL_E28F400B,        intel_e28f400b_device)
 DECLARE_DEVICE_TYPE(MACRONIX_29F008TC,     macronix_29f008tc_device)
 DECLARE_DEVICE_TYPE(MACRONIX_29L001MC,     macronix_29l001mc_device)
 DECLARE_DEVICE_TYPE(MACRONIX_29LV160TMC,   macronix_29lv160tmc_device)
+DECLARE_DEVICE_TYPE(MACRONIX_29F1610,      macronix_29f1610_device)
 DECLARE_DEVICE_TYPE(TMS_29F040,            tms_29f040_device)
 
 DECLARE_DEVICE_TYPE(PANASONIC_MN63F805MNP, panasonic_mn63f805mnp_device)

--- a/src/devices/machine/watchdog.cpp
+++ b/src/devices/machine/watchdog.cpp
@@ -83,7 +83,8 @@ void watchdog_timer_device::device_reset()
 	// set up the watchdog timer; only start off enabled if explicitly configured
 	m_enabled = (m_vblank_count != 0 || m_time != attotime::zero);
 	watchdog_reset();
-	m_enabled = true;
+	// Not sure if this is here by mistake? Removing since it's antithetical to the previous commennt. WebTV starts with the watchdog disabled.
+	//m_enabled = true;
 }
 
 

--- a/src/emu/xtal.cpp
+++ b/src/emu/xtal.cpp
@@ -205,6 +205,7 @@ const double XTAL::known_xtals[] = {
 	 12'000'000, /* 12_MHz_XTAL            Extremely common, used on 100's of PCBs */
 	 12'057'600, /* 12.0576_MHz_XTAL       Poly 1 (38400 * 314) */
 	 12'096'000, /* 12.096_MHz_XTAL        Some early 80's Atari games */
+	 12'272'700, /* 12.2727_MHz_XTAL       Drives the FS6182 VCXO to generate the UltimateTV's pixel clock */
 	 12'288'000, /* 12.288_MHz_XTAL        Sega Model 3 digital audio board */
 	 12'292'000, /* 12.292_MHz_XTAL        Northwest Digitial Systems GP-19 */
 	 12'324'000, /* 12.324_MHz_XTAL        Otrona Attache */
@@ -355,6 +356,7 @@ const double XTAL::known_xtals[] = {
 	 24'167'829, /* 24.167829_MHz_XTAL     Neo Geo AES rev. 3-3 and later (~1536x NTSC line rate) */
 	 24'270'000, /* 24.27_MHz_XTAL         CIT-101XL */
 	 24'300'000, /* 24.3_MHz_XTAL          ADM 36 132-column display clock */
+	 24'545'400, /* 24.5454_MHz_XTAL       WebTV's SAA7187 video encoder clock */
 	 24'576'000, /* 24.576_MHz_XTAL        Pole Position h/w, Model 3 CPU board */
 	 24'883'200, /* 24.8832_MHz_XTAL       DEC VT100 */
 	 25'000'000, /* 25_MHz_XTAL            Namco System 22, Taito GNET, Dogyuun h/w */
@@ -438,6 +440,7 @@ const double XTAL::known_xtals[] = {
 	 39'710'000, /* 39.71_MHz_XTAL         Wyse WY-60 132-column display clock */
 	 40'000'000, /* 40_MHz_XTAL            - */
 	 40'210'000, /* 40.21_MHz_XTAL         Fairlight CMI IIx */
+	 40'320'000, /* 40.32_MHz_XTAL         Clock on WebTV's Rockwell RC288DPL modem */
 	 41'539'000, /* 41.539_MHz_XTAL        IBM PS/2 132-column text mode */
 	 42'000'000, /* 42_MHz_XTAL            BMC A-00211 - Popo Bear */
 	 42'105'200, /* 42.1052_MHz_XTAL       NEC PC-88xx */
@@ -471,6 +474,7 @@ const double XTAL::known_xtals[] = {
 	 53'693'175, /* 53.693175_MHz_XTAL     PSX-based h/w, Sony ZN1-2-based (15x NTSC subcarrier) */
 	 54'000'000, /* 54_MHz_XTAL            Taito JC */
 	 55'000'000, /* 55_MHz_XTAL            Eolith Vega */
+	 56'448'000, /* 56.448_MHz_XTAL        Drives WebTV's SPOT ASIC and Rockwell RCVDL56ACFW modem (44100 * 1280) */
 	 57'272'727, /* 57.272727_MHz_XTAL     Psikyo SH2 with /2 divider (16x NTSC subcarrier)*/
 	 57'283'200, /* 57.2832_MHz_XTAL       Macintosh IIci RBV, 15-inch portrait display */
 	 58'000'000, /* 58_MHz_XTAL            Magic Reel (Play System) */

--- a/src/mame/layout/webtv.lay
+++ b/src/mame/layout/webtv.lay
@@ -8,34 +8,41 @@
 		<disk state="1"><color red="0.75" green="0.65" blue="0.0" /></disk>
 		<disk state="0"><color red="0.20" green="0.15" blue="0.0" /></disk>
 	</element>
-    <element name="message_led" defstate="0">
+	<element name="message_led" defstate="0">
 		<disk state="1"><color red="0.75" green="0.0" blue="0.0" /></disk>
 		<disk state="0"><color red="0.20" green="0.0" blue="0.0" /></disk>
 	</element>
 
-    <element name="text_power">
-        <text string="POWER"><color red="0.6" green="0.6" blue="0.6" /></text>
-    </element>
+	<element name="text_power">
+		<text string="POWER"><color red="0.6" green="0.6" blue="0.6" /></text>
+	</element>
 	<element name="text_connect">
-        <text string="CONNECTED"><color red="0.6" green="0.6" blue="0.6" /></text>
-    </element>
+		<text string="CONNECTED"><color red="0.6" green="0.6" blue="0.6" /></text>
+	</element>
 	<element name="text_message">
-        <text string="MESSAGE"><color red="0.6" green="0.6" blue="0.6" /></text>
-    </element>
+		<text string="MESSAGE"><color red="0.6" green="0.6" blue="0.6" /></text>
+	</element>
+
+	<group name="status_leds">
+		<element ref="text_power"><bounds x="0" y="5" width="30" height="10" /></element>
+		<element name="power_led" ref="power_led"><bounds x="5" y="15" width="20" height="20" /></element>
+
+		<element ref="text_connect"><bounds x="35" y="5" width="30" height="10" /></element>
+		<element name="connect_led" ref="connect_led"><bounds x="40" y="15" width="20" height="20" /></element>
+
+		<element ref="text_message"><bounds x="70" y="5" width="30" height="10" /></element>
+		<element name="message_led" ref="message_led"><bounds x="75" y="15" width="20" height="20" /></element>
+	</group>
 
 	<view name="Default Layout">
 		<screen index="0">
-			<bounds x="0" y="0" width="640" height="480" />
+			<bounds x="0" y="0" width="~scr0width~" height="~scr0height~" />
 		</screen>
-		<collection name="Status LEDs" visible="yes">
-		    <element ref="text_power"><bounds x="0" y="485" width="30" height="10" /></element>
-			<element name="power_led" ref="power_led"><bounds x="5" y="495" width="20" height="20" /></element>
 
-		    <element ref="text_connect"><bounds x="35" y="485" width="30" height="10" /></element>
-			<element name="connect_led" ref="connect_led"><bounds x="40" y="495" width="20" height="20" /></element>
-            
-		    <element ref="text_message"><bounds x="70" y="485" width="30" height="10" /></element>
-			<element name="message_led" ref="message_led"><bounds x="75" y="495" width="20" height="20" /></element>
+		<collection name="Status LEDs" visible="yes">
+			<group ref="status_leds">
+				<bounds x="0" y="~scr0height~" width="95" height="30" />
+			</group>
 		</collection>
-    </view>
+	</view>
 </mamelayout>

--- a/src/mame/layout/webtv.lay
+++ b/src/mame/layout/webtv.lay
@@ -23,22 +23,6 @@
         <text string="MESSAGE"><color red="0.6" green="0.6" blue="0.6" /></text>
     </element>
 
-	<element name="sel_pbuff_title">
-		<text string="Pixel Buff">
-			<color red="0.6" green="0.6" blue="0.6" />
-		</text>
-	</element>
-	<element name="sel_pbuff" defstate="0">
-		<text state="0" string="B0">
-			<color red="0.66" green="0.66" blue="0.66"/>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
-		</text>
-		<text state="1" string="B1">
-			<color red="0.86" green="0.86" blue="0.86"/>
-			<bounds x="0.05" y="0.05" width="0.90" height="0.90"/>
-		</text>
-	</element>
-
 	<view name="Default Layout">
 		<screen index="0">
 			<bounds x="0" y="0" width="640" height="480" />
@@ -52,10 +36,6 @@
             
 		    <element ref="text_message"><bounds x="70" y="485" width="30" height="10" /></element>
 			<element name="message_led" ref="message_led"><bounds x="75" y="495" width="20" height="20" /></element>
-		</collection>
-		<collection name="Software State" visible="yes">
-		    <element ref="sel_pbuff_title"><bounds x="610" y="485" width="30" height="10" /></element>
-			<element ref="sel_pbuff" inputtag="emu_config" inputmask="0x01"><bounds x="615" y="495" width="20" height="20" /></element>
 		</collection>
     </view>
 </mamelayout>

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -421,12 +421,12 @@ void spot_asic_device::watchdog_enable(int state)
 {
 	m_wdenable = state;
 
-	m_watchdog->watchdog_enable(m_wdenable);
-
 	if(m_wdenable)
 		m_watchdog->set_time(attotime::from_usec(WATCHDOG_TIMER_USEC));
 	else
 		m_watchdog->set_time(attotime::zero);
+
+	m_watchdog->watchdog_enable(m_wdenable);
 }
 
 uint32_t spot_asic_device::reg_0000_r()

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -466,7 +466,10 @@ void spot_asic_device::reg_0004_w(uint32_t data)
 uint32_t spot_asic_device::reg_0008_r()
 {
 	logerror("%s: reg_0008_r (BUS_INTSTAT)\n", machine().describe_context());
-	return m_intstat;
+	if(m_intstat == 0x0)
+		return BUS_INT_VIDINT;
+	else
+		return m_intstat;
 }
 
 void spot_asic_device::reg_0108_w(uint32_t data)

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -1484,9 +1484,9 @@ TIMER_CALLBACK_MEMBER(spot_asic_device::dac_update)
 		{
 			address_space &space = m_hostcpu->space(AS_PROGRAM);
 
-			int16_t samplel = space.read_dword(m_aud_ccnt);
+			int16_t samplel = space.read_word(m_aud_ccnt);
 			m_aud_ccnt += 2;
-			int16_t sampler = space.read_dword(m_aud_ccnt);
+			int16_t sampler = space.read_word(m_aud_ccnt);
 			m_aud_ccnt += 2;
 
 			// For 8-bit we're assuming left-aligned samples

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -350,6 +350,8 @@ void spot_asic_device::device_reset()
 
 	modem_txbuff_size = 0x0;
 	modem_txbuff_index = 0x0;
+
+	spot_asic_device::watchdog_enable(m_wdenable);
 }
 
 void spot_asic_device::validate_active_area()

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -515,7 +515,8 @@ void spot_asic_device::reg_010c_w(uint32_t data)
         logerror("%s: DEVKBD bus interrupt cleared\n", machine().describe_context());
     if (data&BUS_INT_VIDINT)
         logerror("%s: VIDINT bus interrupt cleared\n", machine().describe_context());
-    m_intenable &= (~data) & 0xFF;
+	if(data != BUS_INT_DEVMOD) // The modem timinng is incorrect, so ignore the ROM trying to disable the modem interrupt.
+		m_intenable &= ~(data & 0xFF);
 }
 
 uint32_t spot_asic_device::reg_0010_r()
@@ -924,7 +925,7 @@ uint32_t spot_asic_device::reg_3038_r()
 void spot_asic_device::reg_3138_w(uint32_t data)
 {
 	//logerror("%s: reg_3138_w %08x (VID_INTSTAT clear)\n", machine().describe_context(), data);
-	 m_vid_intstat &= (~data) & 0xff;
+	m_vid_intstat &= (~data) & 0xff;
 }
 
 uint32_t spot_asic_device::reg_303c_r()
@@ -1511,7 +1512,6 @@ void spot_asic_device::irq_audio_w(int state)
 
 void spot_asic_device::irq_modem_w(int state)
 {
-	m_intenable |= BUS_INT_DEVMOD;
 	spot_asic_device::set_bus_irq(BUS_INT_DEVMOD, state);
 }
 

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -274,6 +274,10 @@ void spot_asic_device::device_start()
 	save_item(NAME(m_smrtcrd_serial_bitmask));
 	save_item(NAME(m_smrtcrd_serial_rxdata));
 	save_item(NAME(m_ledstate));
+	save_item(NAME(dev_idcntl));
+	save_item(NAME(dev_id_state));
+	save_item(NAME(dev_id_bit));
+	save_item(NAME(dev_id_bitidx));
 }
 
 void spot_asic_device::device_reset()
@@ -330,6 +334,11 @@ void spot_asic_device::device_reset()
 	m_power_led = 0;
 	m_connect_led = 0;
 	m_message_led = 0;
+
+	dev_idcntl = 0x00;
+	dev_id_state = SSID_STATE_IDLE;
+	dev_id_bit = 0x0;
+	dev_id_bitidx = 0x0;
 
 	m_smrtcrd_serial_bitmask = 0x0;
 	m_smrtcrd_serial_rxdata = 0x0;

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -273,6 +273,8 @@ void spot_asic_device::device_start()
 	save_item(NAME(m_aud_dmacntl));
 	save_item(NAME(m_smrtcrd_serial_bitmask));
 	save_item(NAME(m_smrtcrd_serial_rxdata));
+	save_item(NAME(m_rom_cntl0));
+	save_item(NAME(m_rom_cntl1));
 	save_item(NAME(m_ledstate));
 	save_item(NAME(dev_idcntl));
 	save_item(NAME(dev_id_state));
@@ -329,6 +331,9 @@ void spot_asic_device::device_reset()
 
 	m_vid_drawstart = 0x0;
 	m_vid_drawvsize = m_vid_vsize;
+
+	m_rom_cntl0 = 0x0;
+	m_rom_cntl1 = 0x0;
 
 	m_ledstate = 0xFFFFFFFF;
 	m_power_led = 0;
@@ -611,23 +616,25 @@ uint32_t spot_asic_device::reg_1000_r()
 uint32_t spot_asic_device::reg_1004_r()
 {
 	logerror("%s: reg_1004_r (ROM_CNTL0)\n", machine().describe_context());
-	return 0;
+	return m_rom_cntl0;
 }
 
 void spot_asic_device::reg_1004_w(uint32_t data)
 {
 	logerror("%s: reg_1004_w %08x (ROM_CNTL0)\n", machine().describe_context(), data);
+	m_rom_cntl0 = data;
 }
 
 uint32_t spot_asic_device::reg_1008_r()
 {
 	logerror("%s: reg_1008_r (ROM_CNTL1)\n", machine().describe_context());
-	return 0;
+	return m_rom_cntl1;
 }
 
 void spot_asic_device::reg_1008_w(uint32_t data)
 {
 	logerror("%s: reg_1008_w %08x (ROM_CNTL1)\n", machine().describe_context(), data);
+	m_rom_cntl1 = data;
 }
 
 uint32_t spot_asic_device::reg_2000_r()

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -916,7 +916,8 @@ uint32_t spot_asic_device::reg_3034_r()
 {
 	//logerror("%s: reg_3034_r (VID_CLINE)\n", machine().describe_context());
 
-	return (m_vid_cline++) & 0x1ffff;
+	return m_screen->vpos();
+	//return (m_vid_cline++) & 0x1ffff;
 }
 
 uint32_t spot_asic_device::reg_3038_r()

--- a/src/mame/webtv/spot_asic.cpp
+++ b/src/mame/webtv/spot_asic.cpp
@@ -1104,16 +1104,17 @@ void spot_asic_device::reg_4010_w(uint32_t data)
 		m_smrtcrd_serial_bitmask = (m_smrtcrd_serial_bitmask << 1) | 1;
 		m_smrtcrd_serial_rxdata = (m_smrtcrd_serial_rxdata << 1) | (data == 0);
 
-		// Just checking if the start and stop bits are present. Not checking if they're valid.
+		// Just checking if the all bits are present. Not checking if they're valid.
 		if ((m_smrtcrd_serial_bitmask & 0x7ff) == 0x7ff)
 		{
+			uint8_t bangserial_config = (m_emu_config->read() & EMUCONFIG_BANGSERIAL);
 			uint8_t rxbyte = 0x00;
 
-			if (m_emu_config->read() & EMUCONFIG_BANGSERIAL_V1)
-				// V1: there's 2 start bits (1 high and 1 low), 8 data bits and 1 stop bit.
+			if((bangserial_config == EMUCONFIG_BANGSERIAL_AUTO && ((m_smrtcrd_serial_rxdata & 0x700) != 0x600)) || (bangserial_config == EMUCONFIG_BANGSERIAL_V1))
+				// V1: there's 2 bits at the start (1 high and 1 low), 8 data bits and 1 bit at the end.
 				rxbyte = (m_smrtcrd_serial_rxdata >> 1);
 			else
-				// V2: there's 3 start bits (all high), 8 data bits and no stop bit.
+				// V2: there's 3 bits at the start (all high), 8 data bits and no bits at the end.
 				rxbyte = m_smrtcrd_serial_rxdata;
 
 			// This reverses the bit order
@@ -1123,10 +1124,10 @@ void spot_asic_device::reg_4010_w(uint32_t data)
 
 			osd_printf_verbose("%c", rxbyte);
 
-            m_smrtcrd_serial_bitmask = 0x0;
-            m_smrtcrd_serial_rxdata = 0x0;
-        }
-    }
+			m_smrtcrd_serial_bitmask = 0x0;
+			m_smrtcrd_serial_rxdata = 0x0;
+		}
+	}
     else
     {
         // TODO: reimplement smartcard slot

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -41,12 +41,13 @@
 #define SYSCONFIG_CPUBUFF    1 << 13 // 0=50% output buffer strength, 1=83% output buffer strength
 #define SYSCONFIG_NTSC       1 << 11 // use NTSC mode
 
-#define EMUCONFIG_PBUFF0         0	  // Render the screen using data exactly at nstart. Only seen in the prealpha bootrom.
-#define EMUCONFIG_PBUFF1         1 << 0 // Render the screen using data one buffer length beyond nstart. Seems to be what they settled on.
-#define EMUCONFIG_BANGSERIAL     3 << 2
-#define EMUCONFIG_BANGSERIAL_V1  1 << 2
-#define EMUCONFIG_BANGSERIAL_V2  1 << 3
-#define EMUCONFIG_SCREEN_UPDATES 1 << 4
+#define EMUCONFIG_PBUFF0          0	  // Render the screen using data exactly at nstart. Only seen in the prealpha bootrom.
+#define EMUCONFIG_PBUFF1          1 << 0 // Render the screen using data one buffer length beyond nstart. Seems to be what they settled on.
+#define EMUCONFIG_BANGSERIAL      3 << 2
+#define EMUCONFIG_BANGSERIAL_V1   1 << 2
+#define EMUCONFIG_BANGSERIAL_V2   1 << 3
+#define EMUCONFIG_BANGSERIAL_AUTO 3 << 2
+#define EMUCONFIG_SCREEN_UPDATES  1 << 4
 
 #define ERR_F1READ  1 << 6 // BUS_FENADDR1 read fence check error
 #define ERR_F1WRITE 1 << 5 // BUS_FENADDR1 write fence check error

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -49,6 +49,22 @@
 #define EMUCONFIG_BANGSERIAL_AUTO 3 << 2
 #define EMUCONFIG_SCREEN_UPDATES  1 << 4
 
+#define CHPCNTL_WDENAB_MASK     3 << 30
+#define CHPCNTL_WDENAB_SEQ0     0 << 30
+#define CHPCNTL_WDENAB_SEQ1     1 << 30
+#define CHPCNTL_WDENAB_SEQ2     2 << 30
+#define CHPCNTL_WDENAB_SEQ3     3 << 30
+#define CHPCNTL_WDENAB_DWN     -1 << 30
+#define CHPCNTL_WDENAB_UP       1 << 30
+#define CHPCNTL_AUDCLKDIV_MASK  15 << 26
+#define CHPCNTL_AUDCLKDIV_EXTC  0 << 26
+#define CHPCNTL_AUDCLKDIV_DIV1  1 << 26
+#define CHPCNTL_AUDCLKDIV_DIV2  2 << 26
+#define CHPCNTL_AUDCLKDIV_DIV3  3 << 26
+#define CHPCNTL_AUDCLKDIV_DIV4  4 << 26
+#define CHPCNTL_AUDCLKDIV_DIV5  5 << 26
+#define CHPCNTL_AUDCLKDIV_DIV6  6 << 26
+
 #define ERR_F1READ  1 << 6 // BUS_FENADDR1 read fence check error
 #define ERR_F1WRITE 1 << 5 // BUS_FENADDR1 write fence check error
 #define ERR_F2READ  1 << 4 // BUS_FENADDR2 read fence check error
@@ -124,7 +140,7 @@
 #define AUD_CONFIG_8BIT_STEREO  2
 #define AUD_CONFIG_8BIT_MONO    3
 
-#define AUD_SAMPLE_RATE 44100
+#define AUD_DEFAULT_CLK 44100
 #define AUD_OUTPUT_GAIN 0.25
 
 #define AUD_DMACNTL_DMAEN  1 << 2 // audUnit DMA channel enabled

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -225,6 +225,9 @@ protected:
 	uint32_t m_aud_nconfig;
 	uint32_t m_aud_dmacntl;
 
+	uint32_t m_rom_cntl0;
+	uint32_t m_rom_cntl1;
+
 	uint32_t dev_idcntl;
 	uint8_t dev_id_state;
 	uint8_t dev_id_bit;

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -146,7 +146,7 @@ constexpr uint32_t AUD_CONFIG_8BIT_STEREO  = 2;
 constexpr uint32_t AUD_CONFIG_8BIT_MONO    = 3;
 
 constexpr uint32_t AUD_DEFAULT_CLK = 44100;
-constexpr float    AUD_OUTPUT_GAIN = 0.25;
+constexpr float    AUD_OUTPUT_GAIN = 0.45;
 
 constexpr uint32_t AUD_DMACNTL_DMAEN  = 1 << 2; // audUnit DMA channel enabled
 constexpr uint32_t AUD_DMACNTL_NV     = 1 << 1; // audUnit DMA next registers are valid

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -224,8 +224,13 @@ protected:
 	uint32_t m_vid_intenable;
 	uint32_t m_vid_intstat;
 
-	uint32_t m_vid_drawstart;
-	uint32_t m_vid_drawvsize;
+	// Values set from software are corrected then stored here to draw the actual screen.
+	uint32_t m_vid_draw_nstart;
+	uint32_t m_vid_draw_hstart;
+	uint32_t m_vid_draw_hsize;
+	uint32_t m_vid_draw_vstart;
+	uint32_t m_vid_draw_vsize;
+	uint32_t m_vid_draw_blank_color;
 
 	uint8_t m_aud_clkdiv;
 	uint32_t m_aud_cstart;

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -47,7 +47,6 @@
 #define EMUCONFIG_BANGSERIAL_V1   1 << 2
 #define EMUCONFIG_BANGSERIAL_V2   1 << 3
 #define EMUCONFIG_BANGSERIAL_AUTO 3 << 2
-#define EMUCONFIG_SCREEN_UPDATES  1 << 4
 
 #define CHPCNTL_WDENAB_MASK     3 << 30
 #define CHPCNTL_WDENAB_SEQ0     0 << 30
@@ -81,30 +80,38 @@
 #define BUS_INT_DEVSMC 1 << 3 // SmartCard inserted
 #define BUS_INT_AUDDMA 1 << 2 // audUnit DMA completion
 
-#define NTSC_SCREEN_XTAL   XTAL(18'414'000)
-#define NTSC_SCREEN_WIDTH  640
-#define NTSC_SCREEN_HSTART 40
-#define NTSC_SCREEN_HSIZE  560
-#define NTSC_SCREEN_HEIGHT 480
-#define NTSC_SCREEN_VSTART 30
-#define NTSC_SCREEN_VSIZE  420
+// These are guessed pixel clocks. They were chosen because they cause expected behaviour in emulation.
 
-#define PAL_SCREEN_XTAL   XTAL(21'060'000)
-#define PAL_SCREEN_WIDTH  768
-#define PAL_SCREEN_HSTART 72
-#define PAL_SCREEN_HSIZE  624
-#define PAL_SCREEN_HEIGHT 560
-#define PAL_SCREEN_VSTART 40
-#define PAL_SCREEN_VSIZE  480
+#define NTSC_SCREEN_XTAL    18393540 // Pixel clock. 480 lines and 640 "pixes" per line @ 60Hz
+#define NTSC_SCREEN_HTOTAL  640      // Total pixels per line (total screen width)
+#define NTSC_SCREEN_HSTART  40       // How many pixel before the active screen starts
+#define NTSC_SCREEN_HSIZE   560      // How many pixels to draw (active screen width)
+#define NTSC_SCREEN_HBSTART 640      // How many pixels before the blanking interval starts
+#define NTSC_SCREEN_VTOTAL  480      // Total lines (total screen height)
+#define NTSC_SCREEN_VSTART  30       // How many lines before the active screen starts
+#define NTSC_SCREEN_VSIZE   420      // How many lines to draw (active screen height)
+#define NTSC_SCREEN_VBSTART 480      // How many lines before the blanking interval starts
 
-#define VID_DEFAULT_XTAL   NTSC_SCREEN_XTAL
-#define VID_DEFAULT_WIDTH  NTSC_SCREEN_WIDTH
-#define VID_DEFAULT_HSTART NTSC_SCREEN_HSTART
-#define VID_DEFAULT_HSIZE  NTSC_SCREEN_HSIZE
-#define VID_DEFAULT_HEIGHT NTSC_SCREEN_HEIGHT
-#define VID_DEFAULT_VSTART NTSC_SCREEN_VSTART
-#define VID_DEFAULT_VSIZE  NTSC_SCREEN_VSIZE
-// This is always 0x77 on SPOT and SOLO for some reason (even on hardware)
+#define PAL_SCREEN_XTAL    21465500 // Pixel clock. 560 lines and 768 "pixes" per line @ 50Hz
+#define PAL_SCREEN_HTOTAL  768      // Total pixels per line (total screen width)
+#define PAL_SCREEN_HSTART  72       // How many pixel before the active screen starts
+#define PAL_SCREEN_HSIZE   624      // How many pixels to draw (active screen width)
+#define PAL_SCREEN_HBSTART 768      // How many pixels before the blanking interval starts
+#define PAL_SCREEN_VTOTAL  560      // Total lines (total screen height)
+#define PAL_SCREEN_VSTART  40       // How many lines before the active screen starts
+#define PAL_SCREEN_VSIZE   480      // How many lines to draw (active screen height)
+#define PAL_SCREEN_VBSTART 560      // How many lines before the blanking interval starts
+
+#define VID_DEFAULT_XTAL    NTSC_SCREEN_XTAL
+#define VID_DEFAULT_HTOTAL  NTSC_SCREEN_HTOTAL
+#define VID_DEFAULT_HSTART  NTSC_SCREEN_HSTART
+#define VID_DEFAULT_HBSTART NTSC_SCREEN_HBSTART
+#define VID_DEFAULT_HSIZE   NTSC_SCREEN_HSIZE
+#define VID_DEFAULT_VTOTAL  NTSC_SCREEN_VTOTAL
+#define VID_DEFAULT_VSTART  NTSC_SCREEN_VSTART
+#define VID_DEFAULT_VBSTART NTSC_SCREEN_VBSTART
+#define VID_DEFAULT_VSIZE   NTSC_SCREEN_VSIZE
+// This is always 0x77 on SPOT for some reason (even on hardware)
 // This is needed to correct the HSTART value.
 #define VID_HSTART_OFFSET  0x77
 
@@ -155,7 +162,7 @@
 #define INS8250_LSR_TSRE 0x40
 #define INS8250_LSR_THRE 0x20
 #define MBUFF_MAX_SIZE   0x800
-#define MBUFF_FLUSH_TIME 100
+#define MBUFF_FLUSH_TIME 100   // time is in microseconds
 
 #define SSID_STATE_IDLE               0x0
 #define SSID_STATE_RESET              0x1
@@ -185,15 +192,13 @@ public:
 
 	uint32_t screen_update(screen_device &screen, bitmap_rgb32 &bitmap, const rectangle &cliprect);
 
-	void pixel_buffer_index_update();
 protected:
 	// device-level overrides
 	virtual void device_add_mconfig(machine_config &config) override;
+	virtual void device_resolve_objects() override;
 	virtual void device_start() override;
 	virtual void device_reset() override;
 	virtual void device_stop() override;
-
-	void reconfigure_screen(bool use_pal);
 
 	uint32_t m_chpcntl;
 	uint8_t m_wdenable;
@@ -319,6 +324,7 @@ private:
 	void validate_active_area();
 	void spot_update_cycle_counting();
 	void watchdog_enable(int state);
+	void pixel_buffer_index_update();
 
 	/* busUnit registers */
 

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -32,146 +32,144 @@
 #include "speaker.h"
 #include "machine/watchdog.h"
 
-#define SYSCONFIG_ROMTYP0    1 << 31 // ROM bank 0 is present
-#define SYSCONFIG_ROMMODE0   1 << 30 // ROM bank 0 supports page mode
-#define SYSCONFIG_ROMTYP1    1 << 27 // ROM bank 1 is present
-#define SYSCONFIG_ROMMODE1   1 << 26 // ROM bank 1 supports page mode
-#define SYSCONFIG_AUDDACMODE 1 << 17 // use external DAC clock
-#define SYSCONFIG_VIDCLKSRC  1 << 16 // use external video encoder clock
-#define SYSCONFIG_CPUBUFF    1 << 13 // 0=50% output buffer strength, 1=83% output buffer strength
-#define SYSCONFIG_NTSC       1 << 11 // use NTSC mode
+constexpr uint32_t SYSCONFIG_ROMTYP0    = 1 << 31; // ROM bank 0 is present
+constexpr uint32_t SYSCONFIG_ROMMODE0   = 1 << 30; // ROM bank 0 supports page mode
+constexpr uint32_t SYSCONFIG_ROMTYP1    = 1 << 27; // ROM bank 1 is present
+constexpr uint32_t SYSCONFIG_ROMMODE1   = 1 << 26; // ROM bank 1 supports page mode
+constexpr uint32_t SYSCONFIG_AUDDACMODE = 1 << 17; // use external DAC clock
+constexpr uint32_t SYSCONFIG_VIDCLKSRC  = 1 << 16; // use external video encoder clock
+constexpr uint32_t SYSCONFIG_CPUBUFF    = 1 << 13; // 0=50% output buffer strength, 1=83% output buffer strength
+constexpr uint32_t SYSCONFIG_NTSC       = 1 << 11; // use NTSC mode
 
-#define EMUCONFIG_PBUFF0          0	  // Render the screen using data exactly at nstart. Only seen in the prealpha bootrom.
-#define EMUCONFIG_PBUFF1          1 << 0 // Render the screen using data one buffer length beyond nstart. Seems to be what they settled on.
-#define EMUCONFIG_BANGSERIAL      3 << 2
-#define EMUCONFIG_BANGSERIAL_V1   1 << 2
-#define EMUCONFIG_BANGSERIAL_V2   1 << 3
-#define EMUCONFIG_BANGSERIAL_AUTO 3 << 2
+constexpr uint32_t EMUCONFIG_PBUFF0          = 0;      // Render the screen using data exactly at nstart. Only seen in the prealpha bootrom.
+constexpr uint32_t EMUCONFIG_PBUFF1          = 1 << 0; // Render the screen using data one buffer length beyond nstart. Seems to be what they settled on.
+constexpr uint32_t EMUCONFIG_BANGSERIAL      = 3 << 2;
+constexpr uint32_t EMUCONFIG_BANGSERIAL_V1   = 1 << 2;
+constexpr uint32_t EMUCONFIG_BANGSERIAL_V2   = 1 << 3;
+constexpr uint32_t EMUCONFIG_BANGSERIAL_AUTO = 3 << 2;
 
-#define CHPCNTL_WDENAB_MASK     3 << 30
-#define CHPCNTL_WDENAB_SEQ0     0 << 30
-#define CHPCNTL_WDENAB_SEQ1     1 << 30
-#define CHPCNTL_WDENAB_SEQ2     2 << 30
-#define CHPCNTL_WDENAB_SEQ3     3 << 30
-#define CHPCNTL_WDENAB_DWN     -1 << 30
-#define CHPCNTL_WDENAB_UP       1 << 30
-#define CHPCNTL_AUDCLKDIV_MASK  15 << 26
-#define CHPCNTL_AUDCLKDIV_EXTC  0 << 26
-#define CHPCNTL_AUDCLKDIV_DIV1  1 << 26
-#define CHPCNTL_AUDCLKDIV_DIV2  2 << 26
-#define CHPCNTL_AUDCLKDIV_DIV3  3 << 26
-#define CHPCNTL_AUDCLKDIV_DIV4  4 << 26
-#define CHPCNTL_AUDCLKDIV_DIV5  5 << 26
-#define CHPCNTL_AUDCLKDIV_DIV6  6 << 26
+constexpr uint32_t CHPCNTL_WDENAB_MASK     =  3 << 30;
+constexpr uint32_t CHPCNTL_WDENAB_SEQ0     =  0 << 30;
+constexpr uint32_t CHPCNTL_WDENAB_SEQ1     =  1 << 30;
+constexpr uint32_t CHPCNTL_WDENAB_SEQ2     =  2 << 30;
+constexpr uint32_t CHPCNTL_WDENAB_SEQ3     =  3 << 30;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_MASK  =  15 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_EXTC  =  0 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV1  =  1 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV2  =  2 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV3  =  3 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV4  =  4 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV5  =  5 << 26;
+constexpr uint32_t CHPCNTL_AUDCLKDIV_DIV6  =  6 << 26;
 
-#define ERR_F1READ  1 << 6 // BUS_FENADDR1 read fence check error
-#define ERR_F1WRITE 1 << 5 // BUS_FENADDR1 write fence check error
-#define ERR_F2READ  1 << 4 // BUS_FENADDR2 read fence check error
-#define ERR_F2WRITE 1 << 3 // BUS_FENADDR2 write fence check error
-#define ERR_TIMEOUT 1 << 2 // io timeout error
-#define ERR_OW      1 << 0 // double-fault
+constexpr uint32_t ERR_F1READ  = 1 << 6; // BUS_FENADDR1 read fence check error
+constexpr uint32_t ERR_F1WRITE = 1 << 5; // BUS_FENADDR1 write fence check error
+constexpr uint32_t ERR_F2READ  = 1 << 4; // BUS_FENADDR2 read fence check error
+constexpr uint32_t ERR_F2WRITE = 1 << 3; // BUS_FENADDR2 write fence check error
+constexpr uint32_t ERR_TIMEOUT = 1 << 2; // io timeout error
+constexpr uint32_t ERR_OW      = 1 << 0; // double-fault
 
-#define WATCHDOG_TIMER_USEC 1000000
+constexpr uint32_t WATCHDOG_TIMER_USEC = 1000000;
 
-#define BUS_INT_VIDINT 1 << 7 // vidUnit interrupt (program should read VID_INTSTAT)
-#define BUS_INT_DEVKBD 1 << 6 // keyboard IRQ
-#define BUS_INT_DEVMOD 1 << 5 // modem IRQ
-#define BUS_INT_DEVIR  1 << 4 // IR data ready to read
-#define BUS_INT_DEVSMC 1 << 3 // SmartCard inserted
-#define BUS_INT_AUDDMA 1 << 2 // audUnit DMA completion
+constexpr uint32_t BUS_INT_VIDINT = 1 << 7; // vidUnit interrupt (program should read VID_INTSTAT)
+constexpr uint32_t BUS_INT_DEVKBD = 1 << 6; // keyboard IRQ
+constexpr uint32_t BUS_INT_DEVMOD = 1 << 5; // modem IRQ
+constexpr uint32_t BUS_INT_DEVIR  = 1 << 4; // IR data ready to read
+constexpr uint32_t BUS_INT_DEVSMC = 1 << 3; // SmartCard inserted
+constexpr uint32_t BUS_INT_AUDDMA = 1 << 2; // audUnit DMA completion
 
 // These are guessed pixel clocks. They were chosen because they cause expected behaviour in emulation.
 
-#define NTSC_SCREEN_XTAL    18393540 // Pixel clock. 480 lines and 640 "pixes" per line @ 60Hz
-#define NTSC_SCREEN_HTOTAL  640      // Total pixels per line (total screen width)
-#define NTSC_SCREEN_HSTART  40       // How many pixel before the active screen starts
-#define NTSC_SCREEN_HSIZE   560      // How many pixels to draw (active screen width)
-#define NTSC_SCREEN_HBSTART 640      // How many pixels before the blanking interval starts
-#define NTSC_SCREEN_VTOTAL  480      // Total lines (total screen height)
-#define NTSC_SCREEN_VSTART  30       // How many lines before the active screen starts
-#define NTSC_SCREEN_VSIZE   420      // How many lines to draw (active screen height)
-#define NTSC_SCREEN_VBSTART 480      // How many lines before the blanking interval starts
+constexpr uint32_t NTSC_SCREEN_XTAL    = 18393540; // Pixel clock. 480 lines and 640 "pixes" per line @ 60Hz
+constexpr uint32_t NTSC_SCREEN_HTOTAL  = 640;      // Total pixels per line (total screen width)
+constexpr uint32_t NTSC_SCREEN_HSTART  = 40;       // How many pixel before the active screen starts
+constexpr uint32_t NTSC_SCREEN_HSIZE   = 560;      // How many pixels to draw (active screen width)
+constexpr uint32_t NTSC_SCREEN_HBSTART = 640;      // How many pixels before the blanking interval starts
+constexpr uint32_t NTSC_SCREEN_VTOTAL  = 480;      // Total lines (total screen height)
+constexpr uint32_t NTSC_SCREEN_VSTART  = 30;       // How many lines before the active screen starts
+constexpr uint32_t NTSC_SCREEN_VSIZE   = 420;      // How many lines to draw (active screen height)
+constexpr uint32_t NTSC_SCREEN_VBSTART = 480;      // How many lines before the blanking interval starts
 
-#define PAL_SCREEN_XTAL    21465500 // Pixel clock. 560 lines and 768 "pixes" per line @ 50Hz
-#define PAL_SCREEN_HTOTAL  768      // Total pixels per line (total screen width)
-#define PAL_SCREEN_HSTART  72       // How many pixel before the active screen starts
-#define PAL_SCREEN_HSIZE   624      // How many pixels to draw (active screen width)
-#define PAL_SCREEN_HBSTART 768      // How many pixels before the blanking interval starts
-#define PAL_SCREEN_VTOTAL  560      // Total lines (total screen height)
-#define PAL_SCREEN_VSTART  40       // How many lines before the active screen starts
-#define PAL_SCREEN_VSIZE   480      // How many lines to draw (active screen height)
-#define PAL_SCREEN_VBSTART 560      // How many lines before the blanking interval starts
+constexpr uint32_t PAL_SCREEN_XTAL    = 21465500; // Pixel clock. 560 lines and 768 "pixes" per line @ 50Hz
+constexpr uint32_t PAL_SCREEN_HTOTAL  = 768;      // Total pixels per line (total screen width)
+constexpr uint32_t PAL_SCREEN_HSTART  = 72;       // How many pixel before the active screen starts
+constexpr uint32_t PAL_SCREEN_HSIZE   = 624;      // How many pixels to draw (active screen width)
+constexpr uint32_t PAL_SCREEN_HBSTART = 768;      // How many pixels before the blanking interval starts
+constexpr uint32_t PAL_SCREEN_VTOTAL  = 560;      // Total lines (total screen height)
+constexpr uint32_t PAL_SCREEN_VSTART  = 40;       // How many lines before the active screen starts
+constexpr uint32_t PAL_SCREEN_VSIZE   = 480;      // How many lines to draw (active screen height)
+constexpr uint32_t PAL_SCREEN_VBSTART = 560;      // How many lines before the blanking interval starts
 
-#define VID_DEFAULT_XTAL    NTSC_SCREEN_XTAL
-#define VID_DEFAULT_HTOTAL  NTSC_SCREEN_HTOTAL
-#define VID_DEFAULT_HSTART  NTSC_SCREEN_HSTART
-#define VID_DEFAULT_HBSTART NTSC_SCREEN_HBSTART
-#define VID_DEFAULT_HSIZE   NTSC_SCREEN_HSIZE
-#define VID_DEFAULT_VTOTAL  NTSC_SCREEN_VTOTAL
-#define VID_DEFAULT_VSTART  NTSC_SCREEN_VSTART
-#define VID_DEFAULT_VBSTART NTSC_SCREEN_VBSTART
-#define VID_DEFAULT_VSIZE   NTSC_SCREEN_VSIZE
+constexpr uint32_t VID_DEFAULT_XTAL    = NTSC_SCREEN_XTAL;
+constexpr uint32_t VID_DEFAULT_HTOTAL  = NTSC_SCREEN_HTOTAL;
+constexpr uint32_t VID_DEFAULT_HSTART  = NTSC_SCREEN_HSTART;
+constexpr uint32_t VID_DEFAULT_HBSTART = NTSC_SCREEN_HBSTART;
+constexpr uint32_t VID_DEFAULT_HSIZE   = NTSC_SCREEN_HSIZE;
+constexpr uint32_t VID_DEFAULT_VTOTAL  = NTSC_SCREEN_VTOTAL;
+constexpr uint32_t VID_DEFAULT_VSTART  = NTSC_SCREEN_VSTART;
+constexpr uint32_t VID_DEFAULT_VBSTART = NTSC_SCREEN_VBSTART;
+constexpr uint32_t VID_DEFAULT_VSIZE   = NTSC_SCREEN_VSIZE;
 // This is always 0x77 on SPOT for some reason (even on hardware)
 // This is needed to correct the HSTART value.
-#define VID_HSTART_OFFSET  0x77
+constexpr uint32_t VID_HSTART_OFFSET  = 0x77;
 
-#define VID_Y_BLACK         0x10
-#define VID_Y_WHITE         0xeb
-#define VID_Y_RANGE         (VID_Y_WHITE - VID_Y_BLACK)
-#define VID_UV_OFFSET       0x80
-#define VID_BYTES_PER_PIXEL 2
-#define VID_DEFAULT_COLOR   (VID_UV_OFFSET << 0x10) | (VID_Y_BLACK << 0x08) | VID_UV_OFFSET
+constexpr uint16_t VID_Y_BLACK         = 0x10;
+constexpr uint16_t VID_Y_WHITE         = 0xeb;
+constexpr uint16_t VID_Y_RANGE         = (VID_Y_WHITE - VID_Y_BLACK);
+constexpr uint16_t VID_UV_OFFSET       = 0x80;
+constexpr uint8_t  VID_BYTES_PER_PIXEL = 2;
+constexpr uint32_t VID_DEFAULT_COLOR   = (VID_UV_OFFSET << 0x10) | (VID_Y_BLACK << 0x08) | VID_UV_OFFSET;
 
-#define VID_INT_FIDO   1 << 6 // TODO: docs don't have info on FIDO mode! figure this out!
-#define VID_INT_VSYNCE 1 << 5 // even field VSYNC
-#define VID_INT_VSYNCO 1 << 4 // odd field VSYNC
-#define VID_INT_HSYNC  1 << 3 // HSYNC on line specified by VID_HINTLINE
-#define VID_INT_DMA    1 << 2 // vidUnit DMA completion
+constexpr uint32_t VID_INT_FIDO   = 1 << 6; // TODO: docs don't have info on FIDO mode! figure this out!
+constexpr uint32_t VID_INT_VSYNCE = 1 << 5; // even field VSYNC
+constexpr uint32_t VID_INT_VSYNCO = 1 << 4; // odd field VSYNC
+constexpr uint32_t VID_INT_HSYNC  = 1 << 3; // HSYNC on line specified by VID_HINTLINE
+constexpr uint32_t VID_INT_DMA    = 1 << 2; // vidUnit DMA completion
 
-#define VID_FCNTL_UVSELSWAP  1 << 7 // UV is swapped. 1=YCbYCr, 0=YCrYCb
-#define VID_FCNTL_CRCBINVERT 1 << 6 // invert MSB Cb and Cb
-#define VID_FCNTL_FIDO       1 << 5 // enable FIDO mode. details unknown
-#define VID_FCNTL_GAMMA      1 << 4 // enable gamma correction
-#define VID_FCNTL_BLNKCOLEN  1 << 3 // enable VID_BLANK color
-#define VID_FCNTL_INTERLACE  1 << 2 // interlaced video enabled
-#define VID_FCNTL_PAL        1 << 1 // PAL mode enabled
-#define VID_FCNTL_VIDENAB    1 << 0 // video output enable
+constexpr uint32_t VID_FCNTL_UVSELSWAP  = 1 << 7; // UV is swapped. 1=YCbYCr, 0=YCrYCb
+constexpr uint32_t VID_FCNTL_CRCBINVERT = 1 << 6; // invert MSB Cb and Cb
+constexpr uint32_t VID_FCNTL_FIDO       = 1 << 5; // enable FIDO mode. details unknown
+constexpr uint32_t VID_FCNTL_GAMMA      = 1 << 4; // enable gamma correction
+constexpr uint32_t VID_FCNTL_BLNKCOLEN  = 1 << 3; // enable VID_BLANK color
+constexpr uint32_t VID_FCNTL_INTERLACE  = 1 << 2; // interlaced video enabled
+constexpr uint32_t VID_FCNTL_PAL        = 1 << 1; // PAL mode enabled
+constexpr uint32_t VID_FCNTL_VIDENAB    = 1 << 0; // video output enable
 
-#define VID_DMACNTL_ITRLEN 1 << 3 // interlaced video in DMA channel
-#define VID_DMACNTL_DMAEN  1 << 2 // DMA channel enabled
-#define VID_DMACNTL_NV     1 << 1 // DMA next registers are valid
-#define VID_DMACNTL_NVF    1 << 0 // DMA next registers are always valid
+constexpr uint32_t VID_DMACNTL_ITRLEN = 1 << 3; // interlaced video in DMA channel
+constexpr uint32_t VID_DMACNTL_DMAEN  = 1 << 2; // DMA channel enabled
+constexpr uint32_t VID_DMACNTL_NV     = 1 << 1; // DMA next registers are valid
+constexpr uint32_t VID_DMACNTL_NVF    = 1 << 0; // DMA next registers are always valid
 
-#define AUD_CONFIG_16BIT_STEREO 0
-#define AUD_CONFIG_16BIT_MONO   1
-#define AUD_CONFIG_8BIT_STEREO  2
-#define AUD_CONFIG_8BIT_MONO    3
+constexpr uint32_t AUD_CONFIG_16BIT_STEREO = 0;
+constexpr uint32_t AUD_CONFIG_16BIT_MONO   = 1;
+constexpr uint32_t AUD_CONFIG_8BIT_STEREO  = 2;
+constexpr uint32_t AUD_CONFIG_8BIT_MONO    = 3;
 
-#define AUD_DEFAULT_CLK 44100
-#define AUD_OUTPUT_GAIN 0.25
+constexpr uint32_t AUD_DEFAULT_CLK = 44100;
+constexpr float    AUD_OUTPUT_GAIN = 0.25;
 
-#define AUD_DMACNTL_DMAEN  1 << 2 // audUnit DMA channel enabled
-#define AUD_DMACNTL_NV     1 << 1 // audUnit DMA next registers are valid
-#define AUD_DMACNTL_NVF    1 << 0 // audUnit DMA next registers are always valid
+constexpr uint32_t AUD_DMACNTL_DMAEN  = 1 << 2; // audUnit DMA channel enabled
+constexpr uint32_t AUD_DMACNTL_NV     = 1 << 1; // audUnit DMA next registers are valid
+constexpr uint32_t AUD_DMACNTL_NVF    = 1 << 0; // audUnit DMA next registers are always valid
 
-#define NVCNTL_SCL      1 << 3
-#define NVCNTL_WRITE_EN 1 << 2
-#define NVCNTL_SDA_W    1 << 1
-#define NVCNTL_SDA_R    1 << 0
+constexpr uint32_t NVCNTL_SCL      = 1 << 3;
+constexpr uint32_t NVCNTL_WRITE_EN = 1 << 2;
+constexpr uint32_t NVCNTL_SDA_W    = 1 << 1;
+constexpr uint32_t NVCNTL_SDA_R    = 1 << 0;
 
-#define INS8250_LSR_TSRE 0x40
-#define INS8250_LSR_THRE 0x20
-#define MBUFF_MAX_SIZE   0x800
-#define MBUFF_FLUSH_TIME 100   // time is in microseconds
+constexpr uint8_t  INS8250_LSR_TSRE = 0x40;
+constexpr uint8_t  INS8250_LSR_THRE = 0x20;
+constexpr uint16_t MBUFF_MAX_SIZE   = 0x800;
+constexpr uint16_t MBUFF_FLUSH_TIME = 100;  // time is in microseconds
 
-#define SSID_STATE_IDLE               0x0
-#define SSID_STATE_RESET              0x1
-#define SSID_STATE_PRESENCE           0x2
-#define SSID_STATE_COMMAND            0x3
-#define SSID_STATE_READROM            0x4
-#define SSID_STATE_READROM_PULSESTART 0x5
-#define SSID_STATE_READROM_PULSEEND   0x6
-#define SSID_STATE_READROM_BIT        0x7
+constexpr uint8_t SSID_STATE_IDLE               = 0x0;
+constexpr uint8_t SSID_STATE_RESET              = 0x1;
+constexpr uint8_t SSID_STATE_PRESENCE           = 0x2;
+constexpr uint8_t SSID_STATE_COMMAND            = 0x3;
+constexpr uint8_t SSID_STATE_READROM            = 0x4;
+constexpr uint8_t SSID_STATE_READROM_PULSESTART = 0x5;
+constexpr uint8_t SSID_STATE_READROM_PULSEEND   = 0x6;
+constexpr uint8_t SSID_STATE_READROM_BIT        = 0x7;
 
 class spot_asic_device : public device_t, public device_serial_interface, public device_video_interface
 {
@@ -210,7 +208,7 @@ protected:
 
 	uint8_t m_intenable;
 	uint8_t m_intstat;
-	
+
 	uint8_t m_errenable;
 	uint8_t m_errstat;
 
@@ -290,7 +288,7 @@ private:
 	required_device<speaker_device> m_rspeaker;
 
 	required_device<ns16550_device> m_modem_uart;
-	
+
 	required_device<watchdog_timer_device> m_watchdog;
 
 	required_ioport m_sys_config;
@@ -313,8 +311,8 @@ private:
 	void irq_modem_w(int state);
 
 	uint32_t m_compare_armed;
-    
-    bool m_aud_dma_ongoing;
+
+	bool m_aud_dma_ongoing;
 
 	int m_serial_id_tx;
 
@@ -328,147 +326,147 @@ private:
 
 	/* busUnit registers */
 
-    uint32_t reg_0000_r();          // BUS_CHIPID (read-only)
-    uint32_t reg_0004_r();          // BUS_CHPCNTL (read)
-    void reg_0004_w(uint32_t data); // BUS_CHPCNTL (write)
-    uint32_t reg_0008_r();          // BUS_INTSTAT (read)
-    void reg_0108_w(uint32_t data); // BUS_INTSTAT (clear)
-    uint32_t reg_000c_r();          // BUS_INTEN (read)
-    void reg_000c_w(uint32_t data); // BUS_INTEN (set)
-    void reg_010c_w(uint32_t data); // BUS_INTEN (clear)
-    uint32_t reg_0010_r();          // BUS_ERRSTAT (read)
-    void reg_0110_w(uint32_t data); // BUS_ERRSTAT (clear)
-    uint32_t reg_0014_r();          // BUS_ERREN_S (read)
-    void reg_0014_w(uint32_t data); // BUS_ERREN_S (write)
-    void reg_0114_w(uint32_t data); // BUS_ERREN_C (clear)
-    uint32_t reg_0018_r();          // BUS_ERRADDR (read-only)
-    void reg_0118_w(uint32_t data); // BUS_WDREG_C (clear)
-    uint32_t reg_001c_r();          // BUS_FENADDR1 (read)
-    void reg_001c_w(uint32_t data); // BUS_FENADDR1 (write)
-    uint32_t reg_0020_r();          // BUS_FENMASK1 (read)
-    void reg_0020_w(uint32_t data); // BUS_FENMASK1 (write)
-    uint32_t reg_0024_r();          // BUS_FENADDR1 (read)
-    void reg_0024_w(uint32_t data); // BUS_FENADDR1 (write)
-    uint32_t reg_0028_r();          // BUS_FENMASK2 (read)
-    void reg_0028_w(uint32_t data); // BUS_FENMASK2 (write)
-    
-    /* romUnit registers */
+	uint32_t reg_0000_r();          // BUS_CHIPID (read-only)
+	uint32_t reg_0004_r();          // BUS_CHPCNTL (read)
+	void reg_0004_w(uint32_t data); // BUS_CHPCNTL (write)
+	uint32_t reg_0008_r();          // BUS_INTSTAT (read)
+	void reg_0108_w(uint32_t data); // BUS_INTSTAT (clear)
+	uint32_t reg_000c_r();          // BUS_INTEN (read)
+	void reg_000c_w(uint32_t data); // BUS_INTEN (set)
+	void reg_010c_w(uint32_t data); // BUS_INTEN (clear)
+	uint32_t reg_0010_r();          // BUS_ERRSTAT (read)
+	void reg_0110_w(uint32_t data); // BUS_ERRSTAT (clear)
+	uint32_t reg_0014_r();          // BUS_ERREN_S (read)
+	void reg_0014_w(uint32_t data); // BUS_ERREN_S (write)
+	void reg_0114_w(uint32_t data); // BUS_ERREN_C (clear)
+	uint32_t reg_0018_r();          // BUS_ERRADDR (read-only)
+	void reg_0118_w(uint32_t data); // BUS_WDREG_C (clear)
+	uint32_t reg_001c_r();          // BUS_FENADDR1 (read)
+	void reg_001c_w(uint32_t data); // BUS_FENADDR1 (write)
+	uint32_t reg_0020_r();          // BUS_FENMASK1 (read)
+	void reg_0020_w(uint32_t data); // BUS_FENMASK1 (write)
+	uint32_t reg_0024_r();          // BUS_FENADDR1 (read)
+	void reg_0024_w(uint32_t data); // BUS_FENADDR1 (write)
+	uint32_t reg_0028_r();          // BUS_FENMASK2 (read)
+	void reg_0028_w(uint32_t data); // BUS_FENMASK2 (write)
 
-    uint32_t reg_1000_r();          // ROM_SYSCONF (read-only)
-    uint32_t reg_1004_r();          // ROM_CNTL0 (read)
-    void reg_1004_w(uint32_t data); // ROM_CNTL0 (write)
-    uint32_t reg_1008_r();          // ROM_CNTL1 (read)
-    void reg_1008_w(uint32_t data); // ROM_CNTL1 (write)
+	/* romUnit registers */
+
+	uint32_t reg_1000_r();          // ROM_SYSCONF (read-only)
+	uint32_t reg_1004_r();          // ROM_CNTL0 (read)
+	void reg_1004_w(uint32_t data); // ROM_CNTL0 (write)
+	uint32_t reg_1008_r();          // ROM_CNTL1 (read)
+	void reg_1008_w(uint32_t data); // ROM_CNTL1 (write)
 
 	/* audUnit registers */
 
-    uint32_t reg_2000_r();          // AUD_CSTART (read-only)
-    uint32_t reg_2004_r();          // AUD_CSIZE (read-only)
-    uint32_t reg_2008_r();          // AUD_CCONFIG (read)
-    void reg_2008_w(uint32_t data); // AUD_CCONFIG (write)
-    uint32_t reg_200c_r();          // AUD_CCNT (read-only)
-    uint32_t reg_2010_r();          // AUD_NSTART (read)
-    void reg_2010_w(uint32_t data); // AUD_NSTART (write)
-    uint32_t reg_2014_r();          // AUD_NSIZE (read)
-    void reg_2014_w(uint32_t data); // AUD_NSIZE (write)
-    uint32_t reg_2018_r();          // AUD_NCONFIG (read)
-    void reg_2018_w(uint32_t data); // AUD_NCONFIG (write)
-    uint32_t reg_201c_r();          // AUD_DMACNTL (read)
-    void reg_201c_w(uint32_t data); // AUD_DMACNTL (write)
+	uint32_t reg_2000_r();          // AUD_CSTART (read-only)
+	uint32_t reg_2004_r();          // AUD_CSIZE (read-only)
+	uint32_t reg_2008_r();          // AUD_CCONFIG (read)
+	void reg_2008_w(uint32_t data); // AUD_CCONFIG (write)
+	uint32_t reg_200c_r();          // AUD_CCNT (read-only)
+	uint32_t reg_2010_r();          // AUD_NSTART (read)
+	void reg_2010_w(uint32_t data); // AUD_NSTART (write)
+	uint32_t reg_2014_r();          // AUD_NSIZE (read)
+	void reg_2014_w(uint32_t data); // AUD_NSIZE (write)
+	uint32_t reg_2018_r();          // AUD_NCONFIG (read)
+	void reg_2018_w(uint32_t data); // AUD_NCONFIG (write)
+	uint32_t reg_201c_r();          // AUD_DMACNTL (read)
+	void reg_201c_w(uint32_t data); // AUD_DMACNTL (write)
 
 	/* vidUnit registers */
 
-    uint32_t reg_3000_r();          // VID_CSTART (read-only)
-    uint32_t reg_3004_r();          // VID_CSIZE (read-only)
-    uint32_t reg_3008_r();          // VID_CCNT (read-only)
-    uint32_t reg_300c_r();          // VID_NSTART (read)
-    void reg_300c_w(uint32_t data); // VID_NSTART (write)
-    uint32_t reg_3010_r();          // VID_NSIZE (read)
-    void reg_3010_w(uint32_t data); // VID_NSIZE (write)
-    uint32_t reg_3014_r();          // VID_DMACNTL (read)
-    void reg_3014_w(uint32_t data); // VID_DMACNTL (write)
-    uint32_t reg_3018_r();          // VID_FCNTL (read)
-    void reg_3018_w(uint32_t data); // VID_FCNTL (write)
-    uint32_t reg_301c_r();          // VID_BLNKCOL (read)
-    void reg_301c_w(uint32_t data); // VID_BLNKCOL (write)
-    uint32_t reg_3020_r();          // VID_HSTART (read)
-    void reg_3020_w(uint32_t data); // VID_HSTART (write)
-    uint32_t reg_3024_r();          // VID_HSIZE (read)
-    void reg_3024_w(uint32_t data); // VID_HSIZE (write)
-    uint32_t reg_3028_r();          // VID_VSTART (read)
-    void reg_3028_w(uint32_t data); // VID_VSTART (write)
-    uint32_t reg_302c_r();          // VID_VSIZE (read)
-    void reg_302c_w(uint32_t data); // VID_VSIZE (write)
-    uint32_t reg_3030_r();          // VID_HINTLINE (read)
-    void reg_3030_w(uint32_t data); // VID_HINTLINE (write)
-    uint32_t reg_3034_r();          // VID_CLINE (read-only)
-    uint32_t reg_3038_r();          // VID_INTSTAT (read)
-    void reg_3138_w(uint32_t data); // VID_INTSTAT (clear)
-    uint32_t reg_303c_r();          // VID_INTEN_S (read)
-    void reg_303c_w(uint32_t data); // VID_INTEN_S (write)
-    void reg_313c_w(uint32_t data); // VID_INTEN_C (clear)
+	uint32_t reg_3000_r();          // VID_CSTART (read-only)
+	uint32_t reg_3004_r();          // VID_CSIZE (read-only)
+	uint32_t reg_3008_r();          // VID_CCNT (read-only)
+	uint32_t reg_300c_r();          // VID_NSTART (read)
+	void reg_300c_w(uint32_t data); // VID_NSTART (write)
+	uint32_t reg_3010_r();          // VID_NSIZE (read)
+	void reg_3010_w(uint32_t data); // VID_NSIZE (write)
+	uint32_t reg_3014_r();          // VID_DMACNTL (read)
+	void reg_3014_w(uint32_t data); // VID_DMACNTL (write)
+	uint32_t reg_3018_r();          // VID_FCNTL (read)
+	void reg_3018_w(uint32_t data); // VID_FCNTL (write)
+	uint32_t reg_301c_r();          // VID_BLNKCOL (read)
+	void reg_301c_w(uint32_t data); // VID_BLNKCOL (write)
+	uint32_t reg_3020_r();          // VID_HSTART (read)
+	void reg_3020_w(uint32_t data); // VID_HSTART (write)
+	uint32_t reg_3024_r();          // VID_HSIZE (read)
+	void reg_3024_w(uint32_t data); // VID_HSIZE (write)
+	uint32_t reg_3028_r();          // VID_VSTART (read)
+	void reg_3028_w(uint32_t data); // VID_VSTART (write)
+	uint32_t reg_302c_r();          // VID_VSIZE (read)
+	void reg_302c_w(uint32_t data); // VID_VSIZE (write)
+	uint32_t reg_3030_r();          // VID_HINTLINE (read)
+	void reg_3030_w(uint32_t data); // VID_HINTLINE (write)
+	uint32_t reg_3034_r();          // VID_CLINE (read-only)
+	uint32_t reg_3038_r();          // VID_INTSTAT (read)
+	void reg_3138_w(uint32_t data); // VID_INTSTAT (clear)
+	uint32_t reg_303c_r();          // VID_INTEN_S (read)
+	void reg_303c_w(uint32_t data); // VID_INTEN_S (write)
+	void reg_313c_w(uint32_t data); // VID_INTEN_C (clear)
 
 	/* devUnit registers */
 
-    uint32_t reg_4000_r();          // DEV_IRDATA (read-only)
-    uint32_t reg_4004_r();          // DEV_LED (read)
-    void reg_4004_w(uint32_t data); // DEV_LED (write)
-    uint32_t reg_4008_r();          // DEV_IDCNTL (read)
-    void reg_4008_w(uint32_t data); // DEV_IDCNTL (write)
-    uint32_t reg_400c_r();          // DEV_NVCNTL (read)
-    void reg_400c_w(uint32_t data); // DEV_NVCNTL (write)
-    uint32_t reg_4010_r();          // DEV_SCCNTL (read)
-    void reg_4010_w(uint32_t data); // DEV_SCCNTL (write)
-    uint32_t reg_4014_r();          // DEV_EXTTIME (read)
-    void reg_4014_w(uint32_t data); // DEV_EXTTIME (write)
-    
-    // The boot ROM seems to write to register 4018, which is not mentioned anywhere in the documentation.
+	uint32_t reg_4000_r();          // DEV_IRDATA (read-only)
+	uint32_t reg_4004_r();          // DEV_LED (read)
+	void reg_4004_w(uint32_t data); // DEV_LED (write)
+	uint32_t reg_4008_r();          // DEV_IDCNTL (read)
+	void reg_4008_w(uint32_t data); // DEV_IDCNTL (write)
+	uint32_t reg_400c_r();          // DEV_NVCNTL (read)
+	void reg_400c_w(uint32_t data); // DEV_NVCNTL (write)
+	uint32_t reg_4010_r();          // DEV_SCCNTL (read)
+	void reg_4010_w(uint32_t data); // DEV_SCCNTL (write)
+	uint32_t reg_4014_r();          // DEV_EXTTIME (read)
+	void reg_4014_w(uint32_t data); // DEV_EXTTIME (write)
 
-    uint32_t reg_4020_r();          // DEV_KBD0 (read)
-    void reg_4020_w(uint32_t data); // DEV_KBD0 (write)
-    uint32_t reg_4024_r();          // DEV_KBD1 (read)
-    void reg_4024_w(uint32_t data); // DEV_KBD1 (write)
-    uint32_t reg_4028_r();          // DEV_KBD2 (read)
-    void reg_4028_w(uint32_t data); // DEV_KBD2 (write)
-    uint32_t reg_402c_r();          // DEV_KBD3 (read)
-    void reg_402c_w(uint32_t data); // DEV_KBD3 (write)
-    uint32_t reg_4030_r();          // DEV_KBD4 (read)
-    void reg_4030_w(uint32_t data); // DEV_KBD4 (write)
-    uint32_t reg_4034_r();          // DEV_KBD5 (read)
-    void reg_4034_w(uint32_t data); // DEV_KBD5 (write)
-    uint32_t reg_4038_r();          // DEV_KBD6 (read)
-    void reg_4038_w(uint32_t data); // DEV_KBD6 (write)
-    uint32_t reg_403c_r();          // DEV_KBD7 (read)
-    void reg_403c_w(uint32_t data); // DEV_KBD7 (write)
+	// The boot ROM seems to write to register 4018, which is not mentioned anywhere in the documentation.
 
-    uint32_t reg_4040_r();          // DEV_MOD0 (read)
-    void reg_4040_w(uint32_t data); // DEV_MOD0 (write)
-    uint32_t reg_4044_r();          // DEV_MOD1 (read)
-    void reg_4044_w(uint32_t data); // DEV_MOD1 (write)
-    uint32_t reg_4048_r();          // DEV_MOD2 (read)
-    void reg_4048_w(uint32_t data); // DEV_MOD2 (write)
-    uint32_t reg_404c_r();          // DEV_MOD3 (read)
-    void reg_404c_w(uint32_t data); // DEV_MOD3 (write)
-    uint32_t reg_4050_r();          // DEV_MOD4 (read)
-    void reg_4050_w(uint32_t data); // DEV_MOD4 (write)
-    uint32_t reg_4054_r();          // DEV_MOD5 (read)
-    void reg_4054_w(uint32_t data); // DEV_MOD5 (write)
-    uint32_t reg_4058_r();          // DEV_MOD6 (read)
-    void reg_4058_w(uint32_t data); // DEV_MOD6 (write)
-    uint32_t reg_405c_r();          // DEV_MOD7 (read)
-    void reg_405c_w(uint32_t data); // DEV_MOD7 (write)
+	uint32_t reg_4020_r();          // DEV_KBD0 (read)
+	void reg_4020_w(uint32_t data); // DEV_KBD0 (write)
+	uint32_t reg_4024_r();          // DEV_KBD1 (read)
+	void reg_4024_w(uint32_t data); // DEV_KBD1 (write)
+	uint32_t reg_4028_r();          // DEV_KBD2 (read)
+	void reg_4028_w(uint32_t data); // DEV_KBD2 (write)
+	uint32_t reg_402c_r();          // DEV_KBD3 (read)
+	void reg_402c_w(uint32_t data); // DEV_KBD3 (write)
+	uint32_t reg_4030_r();          // DEV_KBD4 (read)
+	void reg_4030_w(uint32_t data); // DEV_KBD4 (write)
+	uint32_t reg_4034_r();          // DEV_KBD5 (read)
+	void reg_4034_w(uint32_t data); // DEV_KBD5 (write)
+	uint32_t reg_4038_r();          // DEV_KBD6 (read)
+	void reg_4038_w(uint32_t data); // DEV_KBD6 (write)
+	uint32_t reg_403c_r();          // DEV_KBD7 (read)
+	void reg_403c_w(uint32_t data); // DEV_KBD7 (write)
+
+	uint32_t reg_4040_r();          // DEV_MOD0 (read)
+	void reg_4040_w(uint32_t data); // DEV_MOD0 (write)
+	uint32_t reg_4044_r();          // DEV_MOD1 (read)
+	void reg_4044_w(uint32_t data); // DEV_MOD1 (write)
+	uint32_t reg_4048_r();          // DEV_MOD2 (read)
+	void reg_4048_w(uint32_t data); // DEV_MOD2 (write)
+	uint32_t reg_404c_r();          // DEV_MOD3 (read)
+	void reg_404c_w(uint32_t data); // DEV_MOD3 (write)
+	uint32_t reg_4050_r();          // DEV_MOD4 (read)
+	void reg_4050_w(uint32_t data); // DEV_MOD4 (write)
+	uint32_t reg_4054_r();          // DEV_MOD5 (read)
+	void reg_4054_w(uint32_t data); // DEV_MOD5 (write)
+	uint32_t reg_4058_r();          // DEV_MOD6 (read)
+	void reg_4058_w(uint32_t data); // DEV_MOD6 (write)
+	uint32_t reg_405c_r();          // DEV_MOD7 (read)
+	void reg_405c_w(uint32_t data); // DEV_MOD7 (write)
 
 	/* memUnit registers */
 
-    uint32_t reg_5000_r();          // MEM_CNTL (read)
-    void reg_5000_w(uint32_t data); // MEM_CNTL (write)
-    uint32_t reg_5004_r();          // MEM_REFCNT (read)
-    void reg_5004_w(uint32_t data); // MEM_REFCNT (write)
-    uint32_t reg_5008_r();          // MEM_DATA (read)
-    void reg_5008_w(uint32_t data); // MEM_DATA (write)
-    void reg_500c_w(uint32_t data); // MEM_CMD (write-only)
-    uint32_t reg_5010_r();          // MEM_TIMING (read)
-    void reg_5010_w(uint32_t data); // MEM_TIMING (write)
+	uint32_t reg_5000_r();          // MEM_CNTL (read)
+	void reg_5000_w(uint32_t data); // MEM_CNTL (write)
+	uint32_t reg_5004_r();          // MEM_REFCNT (read)
+	void reg_5004_w(uint32_t data); // MEM_REFCNT (write)
+	uint32_t reg_5008_r();          // MEM_DATA (read)
+	void reg_5008_w(uint32_t data); // MEM_DATA (write)
+	void reg_500c_w(uint32_t data); // MEM_CMD (write-only)
+	uint32_t reg_5010_r();          // MEM_TIMING (read)
+	void reg_5010_w(uint32_t data); // MEM_TIMING (write)
 };
 
 DECLARE_DEVICE_TYPE(SPOT_ASIC, spot_asic_device)

--- a/src/mame/webtv/spot_asic.h
+++ b/src/mame/webtv/spot_asic.h
@@ -65,26 +65,39 @@
 #define BUS_INT_DEVSMC 1 << 3 // SmartCard inserted
 #define BUS_INT_AUDDMA 1 << 2 // audUnit DMA completion
 
+#define NTSC_SCREEN_XTAL   XTAL(18'414'000)
 #define NTSC_SCREEN_WIDTH  640
+#define NTSC_SCREEN_HSTART 40
+#define NTSC_SCREEN_HSIZE  560
 #define NTSC_SCREEN_HEIGHT 480
-#define NTSC_SCREEN_HZ     60
-#define PAL_SCREEN_WIDTH   768
-#define PAL_SCREEN_HEIGHT  560
-#define PAL_SCREEN_HZ      50
+#define NTSC_SCREEN_VSTART 30
+#define NTSC_SCREEN_VSIZE  420
+
+#define PAL_SCREEN_XTAL   XTAL(21'060'000)
+#define PAL_SCREEN_WIDTH  768
+#define PAL_SCREEN_HSTART 72
+#define PAL_SCREEN_HSIZE  624
+#define PAL_SCREEN_HEIGHT 560
+#define PAL_SCREEN_VSTART 40
+#define PAL_SCREEN_VSIZE  480
+
+#define VID_DEFAULT_XTAL   NTSC_SCREEN_XTAL
+#define VID_DEFAULT_WIDTH  NTSC_SCREEN_WIDTH
+#define VID_DEFAULT_HSTART NTSC_SCREEN_HSTART
+#define VID_DEFAULT_HSIZE  NTSC_SCREEN_HSIZE
+#define VID_DEFAULT_HEIGHT NTSC_SCREEN_HEIGHT
+#define VID_DEFAULT_VSTART NTSC_SCREEN_VSTART
+#define VID_DEFAULT_VSIZE  NTSC_SCREEN_VSIZE
+// This is always 0x77 on SPOT and SOLO for some reason (even on hardware)
+// This is needed to correct the HSTART value.
+#define VID_HSTART_OFFSET  0x77
 
 #define VID_Y_BLACK         0x10
 #define VID_Y_WHITE         0xeb
 #define VID_Y_RANGE         (VID_Y_WHITE - VID_Y_BLACK)
 #define VID_UV_OFFSET       0x80
 #define VID_BYTES_PER_PIXEL 2
-#define VID_DEFAULT_WIDTH   NTSC_SCREEN_WIDTH
-#define VID_DEFAULT_HEIGHT  NTSC_SCREEN_HEIGHT
-#define VID_DEFAULT_HZ      NTSC_SCREEN_HZ
-#define VID_DEFAULT_HSTART  0
-#define VID_DEFAULT_HSIZE   560
-#define VID_DEFAULT_VSTART  0
-#define VID_DEFAULT_VSIZE   420
-#define VID_DEFAULT_COLOR   (VID_UV_OFFSET << 0x10) | (VID_Y_BLACK << 0x08) | VID_UV_OFFSET;
+#define VID_DEFAULT_COLOR   (VID_UV_OFFSET << 0x10) | (VID_Y_BLACK << 0x08) | VID_UV_OFFSET
 
 #define VID_INT_FIDO   1 << 6 // TODO: docs don't have info on FIDO mode! figure this out!
 #define VID_INT_VSYNCE 1 << 5 // even field VSYNC
@@ -164,8 +177,7 @@ protected:
 	virtual void device_reset() override;
 	virtual void device_stop() override;
 
-	void activate_ntsc_screen();
-	void activate_pal_screen();
+	void reconfigure_screen(bool use_pal);
 
 	uint32_t m_chpcntl;
 	uint8_t m_wdenable;

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -339,10 +339,11 @@ static INPUT_PORTS_START( emu_config )
 	PORT_CONFSETTING(0x00, "Use pixel buffer 0")
 	PORT_CONFSETTING(0x01, "Use pixel buffer 1")
 
-	PORT_CONFNAME(0x0c, 0x08, "Smartcard bangserial")
+	PORT_CONFNAME(0x0c, 0x0c, "Smartcard bangserial")
 	PORT_CONFSETTING(0x00, "Off")
 	PORT_CONFSETTING(0x04, "V1 bangserial data")
 	PORT_CONFSETTING(0x08, "V2 bangserial data")
+	PORT_CONFSETTING(0x0c, "Autodetect")
 
 	PORT_CONFNAME(0x10, 0x10, "Allow real-time screen size updates")
 	PORT_CONFSETTING(0x00, "No")

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -43,8 +43,8 @@
 
 // The system clock is used to drive the SPOT ASIC, drive the CPU and is used to calculate the audio clock.
 // 56.448MHz was probably chosen because it's a multiple of the audio clock? (44100Hz)
-#define SYSCLOCK         XTAL(56'448'000)
-#define RAM_FLASHER_SIZE 0x100
+constexpr XTAL     SYSCLOCK         = XTAL(56'448'000);
+constexpr uint16_t RAM_FLASHER_SIZE = 0x100;
 
 class webtv1_state : public driver_device
 {
@@ -129,7 +129,7 @@ void webtv1_state::bank0_flash_w(offs_t offset, uint32_t data)
 	uint16_t upper_value = (data >> 16) & 0xffff;
 	//upper_value = (upper_value << 8) | ((upper_value >> 8) & 0xff);
 	m_flash0->write(offset, upper_value);
-	
+
 	uint16_t lower_value = data & 0xffff;
 	//lower_value = (lower_value << 8) | ((lower_value >> 8) & 0xff);
 	m_flash1->write(offset, lower_value);
@@ -143,7 +143,7 @@ uint32_t webtv1_state::bank0_flash_r(offs_t offset)
 	//upper_value = (upper_value << 8) | ((upper_value >> 8) & 0xff);
 	uint16_t lower_value = m_flash1->read(offset);
 	//lower_value = (lower_value << 8) | ((lower_value >> 8) & 0xff);
-    return (upper_value << 16) | (lower_value);
+	return (upper_value << 16) | (lower_value);
 }
 
 // WebTV's firmware writes the flashing code to the lower 256 bytes of RAM
@@ -156,11 +156,9 @@ uint8_t webtv1_state::ram_flasher_r(offs_t offset)
 }
 void webtv1_state::ram_flasher_w(offs_t offset, uint8_t data)
 {
-	if(offset == 0)
-	{
+	if (offset == 0)
 		// New code is being written, clear drc cache.
 		m_maincpu->code_flush_cache();
-	}
 
 	ram_flasher[offset & (RAM_FLASHER_SIZE - 1)] = data;
 }
@@ -200,7 +198,7 @@ void webtv1_state::webtv1_base(machine_config &config)
 	m_maincpu->set_icache_size(0x2000);
 	m_maincpu->set_dcache_size(0x2000);
 	m_maincpu->set_addrmap(AS_PROGRAM, &webtv1_state::webtv1_map);
-	
+
 	AMD_29F800B_16BIT(config, m_flash0, 0);
 	AMD_29F800B_16BIT(config, m_flash1, 0);
 
@@ -242,7 +240,7 @@ static INPUT_PORTS_START( sys_config )
 
 	PORT_DIPUNUSED_DIPLOC(0x01, 0x01, "SW1:1")
 	PORT_DIPUNUSED_DIPLOC(0x02, 0x02, "SW1:2")
-	
+
 	PORT_DIPNAME(0x0c, 0x0c, "Board type")
 	PORT_DIPSETTING(0x00, "Reserved")
 	PORT_DIPSETTING(0x04, "Reserved")
@@ -285,7 +283,7 @@ static INPUT_PORTS_START( sys_config )
 	PORT_DIPSETTING(0x40000, "Reserved")
 	PORT_DIPSETTING(0x80000, "Reserved")
 	PORT_DIPSETTING(0xc0000, "AKM 4310/4309")
-	
+
 	PORT_DIPNAME(0x300000, 0x200000, "Memory vendor")
 	PORT_DIPSETTING(0x000000, "Other")
 	PORT_DIPSETTING(0x100000, "Samsung")
@@ -311,7 +309,7 @@ static INPUT_PORTS_START( sys_config )
 	PORT_DIPNAME(0x8000000, 0x8000000, "Bank 1 ROM type")
 	PORT_DIPSETTING(0x0000000, "Flash ROM")
 	PORT_DIPSETTING(0x8000000, "Mask ROM (emulated behavior)")
-	
+
 	PORT_DIPNAME(0x30000000, 0x20000000, "Bank 0 ROM speed")
 	PORT_DIPSETTING(0x00000000, "200ns/100ns")
 	PORT_DIPSETTING(0x10000000, "100ns/50ns")

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -146,8 +146,6 @@ void webtv1_state::webtv1_base(machine_config &config)
 	DS2401(config, m_serial_id, 0);
 
 	I2C_24C01(config, m_nvram, 0);
-	m_nvram->set_e0(0);
-	m_nvram->set_wc(1);
 
 	SPOT_ASIC(config, m_spotasic, SYSCLOCK);
 	m_spotasic->set_hostcpu(m_maincpu);

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -41,7 +41,9 @@
 #include "main.h"
 #include "screen.h"
 
-#define SYSCLOCK         56448000 // confirmed
+// The system clock is used to drive the SPOT ASIC, drive the CPU and is used to calculate the audio clock.
+// 56.448MHz was probably chosen because it's a multiple of the audio clock? (44100Hz)
+#define SYSCLOCK         XTAL(56'448'000)
 #define RAM_FLASHER_SIZE 0x100
 
 class webtv1_state : public driver_device
@@ -57,7 +59,7 @@ public:
 		m_flash0(*this, "bank0_flash0"), // labeled U0501, contains upper bits
 		m_flash1(*this, "bank0_flash1")  // labeled U0502, contains lower bits
 	{ }
-	
+
 	void webtv1_base(machine_config& config);
 	void webtv1_sony(machine_config& config);
 	void webtv1_philips(machine_config& config);
@@ -65,7 +67,7 @@ public:
 protected:
 	virtual void machine_start() override;
 	virtual void machine_reset() override;
-    
+
 private:
 	required_device<mips3_device> m_maincpu;
 	required_device<spot_asic_device> m_spotasic;
@@ -253,6 +255,7 @@ static INPUT_PORTS_START( sys_config )
 	PORT_DIPUNUSED_DIPLOC(0x200, 0x200, "SW1:9")
 	PORT_DIPUNUSED_DIPLOC(0x400, 0x400, "SW1:10")
 
+	// A 24.54MHz or 29.5MHz crystal drives the SAA7187 encoder chip. These pixel clocks are divisors of that input.
 	PORT_DIPNAME(0x800, 0x800, "NTSC/PAL");
 	PORT_DIPSETTING(0x000, "PAL mode w/ 14.75MHz pixel clock")
 	PORT_DIPSETTING(0x800, "NTSC mode w/ 12.26MHz pixel clock")
@@ -337,10 +340,6 @@ static INPUT_PORTS_START( emu_config )
 	PORT_CONFSETTING(0x04, "V1 bangserial data")
 	PORT_CONFSETTING(0x08, "V2 bangserial data")
 	PORT_CONFSETTING(0x0c, "Autodetect")
-
-	PORT_CONFNAME(0x10, 0x10, "Allow real-time screen size updates")
-	PORT_CONFSETTING(0x00, "No")
-	PORT_CONFSETTING(0x10, "Yes")
 INPUT_PORTS_END
 
 static INPUT_PORTS_START( webtv1_input )

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -58,8 +58,6 @@ public:
 		m_flash1(*this, "bank0_flash1")  // labeled U0502, contains lower bits
 	{ }
 	
-	DECLARE_INPUT_CHANGED_MEMBER(pbuff_index_changed);
-	
 	void webtv1_base(machine_config& config);
 	void webtv1_sony(machine_config& config);
 	void webtv1_philips(machine_config& config);
@@ -236,11 +234,6 @@ void webtv1_state::machine_reset()
 
 }
 
-INPUT_CHANGED_MEMBER(webtv1_state::pbuff_index_changed)
-{
-	m_spotasic->pixel_buffer_index_update();
-}
-
 // Sysconfig options are usually configured via resistors on the board.
 static INPUT_PORTS_START( sys_config )
 	PORT_START("sys_config")
@@ -335,7 +328,7 @@ INPUT_PORTS_END
 static INPUT_PORTS_START( emu_config )
 	PORT_START("emu_config")
 
-	PORT_CONFNAME(0x03, 0x00, "Pixel buffer index") PORT_CHANGED_MEMBER(DEVICE_SELF, webtv1_state, pbuff_index_changed, 0)
+	PORT_CONFNAME(0x03, 0x00, "Pixel buffer index")
 	PORT_CONFSETTING(0x00, "Use pixel buffer 0")
 	PORT_CONFSETTING(0x01, "Use pixel buffer 1")
 

--- a/src/mame/webtv/webtv1.cpp
+++ b/src/mame/webtv/webtv1.cpp
@@ -235,7 +235,7 @@ void webtv1_state::machine_reset()
 }
 
 // Sysconfig options are usually configured via resistors on the board.
-static INPUT_PORTS_START( sys_config )
+static INPUT_PORTS_START( retail_sys_config )
 	PORT_START("sys_config")
 
 	PORT_DIPUNUSED_DIPLOC(0x01, 0x01, "SW1:1")
@@ -340,8 +340,8 @@ static INPUT_PORTS_START( emu_config )
 	PORT_CONFSETTING(0x0c, "Autodetect")
 INPUT_PORTS_END
 
-static INPUT_PORTS_START( webtv1_input )
-	PORT_INCLUDE(sys_config)
+static INPUT_PORTS_START( retail_input )
+	PORT_INCLUDE(retail_sys_config)
 	PORT_INCLUDE(emu_config)
 INPUT_PORTS_END
 
@@ -366,5 +366,5 @@ ROM_START( wtv1phil )
 ROM_END
 
 //    YEAR  NAME      PARENT  COMPAT  MACHINE         INPUT         CLASS         INIT        COMPANY               FULLNAME                            FLAGS
-CONS( 1996, wtv1sony,      0,      0, webtv1_sony,    webtv1_input, webtv1_state, empty_init, "Sony",               "INT-W100 WebTV Internet Terminal", MACHINE_NOT_WORKING + MACHINE_NO_SOUND )
-CONS( 1996, wtv1phil,      0,      0, webtv1_philips, webtv1_input, webtv1_state, empty_init, "Philips-Magnavox",   "MAT960 WebTV Internet Terminal",   MACHINE_NOT_WORKING + MACHINE_NO_SOUND )
+CONS( 1996, wtv1sony,      0,      0, webtv1_sony,    retail_input, webtv1_state, empty_init, "Sony",               "INT-W100 WebTV Internet Terminal", MACHINE_NOT_WORKING + MACHINE_NO_SOUND )
+CONS( 1996, wtv1phil,      0,      0, webtv1_philips, retail_input, webtv1_state, empty_init, "Philips-Magnavox",   "MAT960 WebTV Internet Terminal",   MACHINE_NOT_WORKING + MACHINE_NO_SOUND )


### PR DESCRIPTION
- Fix SSID reading when you first startup
- Implemented IIC NVRAM
- Implemented flash identification, erasing and programming
- Bangserial autodetection. Can be helpful if you use the pre-alpha bootrom then boot into a later bfe approm.
- Fixed CPU speed detection
- Fixed RAM size detection
- Watchdog fixes
- Multiple video fixes
- Audio clock is set by the firmware now
- Removed the forced modem interrupt handling so all interrupts are now off by default. Shouldn't cause an issue where an interrupt is raised before the firmware is ready.